### PR TITLE
Add optional prefix/range scanning via an off-heap ART ordered index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # HaloDB Change Log
 
 ## Unreleased
+* Added optional prefix/range scanning via an off-heap adaptive radix tree (ART) ordered index,
+  enabled with `HaloDBOptions.setUseOrderedIndex(true)` (requires a fixed key size). The hash index
+  is unchanged, so point-read latency is unaffected; new `HaloDB.prefixScan(byte[])` returns records
+  in ascending key order.
 * Migrated off-heap memory access from `sun.misc.Unsafe` (deprecated for removal in JDK 23+) to the
   Foreign Function & Memory API (`java.lang.foreign`). Resolves issue #63.
 * Off-heap allocation now uses libc `malloc`/`free` via FFM downcalls; the JNA dependency has been removed.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,35 @@ Therefore, don't interrupt threads while they are doing IO operations.
 
 ### Restrictions. 
 * Size of keys is restricted to 128 bytes.  
-* HaloDB don't support range scans or ordered access.
+* By default HaloDB does not support range scans or ordered access. An optional ordered index enables
+  prefix/range scans — see below.
+
+### Prefix and range scanning (optional).
+By default the in-memory index is a hash table, so reads are point lookups only. Enabling the ordered
+index maintains an additional off-heap [adaptive radix tree](https://db.in.tum.de/~leis/papers/ART.pdf)
+of the key set alongside the hash table, which adds ordered prefix/range scans:
+
+```java
+HaloDBOptions options = new HaloDBOptions();
+options.setUseOrderedIndex(true);   // maintain the ordered side index
+options.setFixedKeySize(8);         // ordered index requires fixed-length keys
+
+HaloDB db = HaloDB.open(directory, options);
+...
+// iterate, in ascending key order, every record whose key begins with `prefix`
+Iterator<Record> it = db.prefixScan(prefix);
+while (it.hasNext()) {
+    Record record = it.next();
+    ...
+}
+```
+
+Notes:
+* The hash index is unchanged, so **point-read latency is unaffected**; the cost of the ordered index
+  is per-write maintenance and roughly 2x the index memory.
+* All keys must be exactly `fixedKeySize` bytes (the ordered index does not support variable-length keys).
+* A `prefixScan` snapshots its matching keys, then reads each record on demand; deletes after the
+  snapshot are skipped. Very large prefix scans hold their matching key set in memory.
 
 # Benchmarks.
 [Benchmarks](docs/benchmarks.md).

--- a/src/main/java/com/oath/halodb/HaloDB.java
+++ b/src/main/java/com/oath/halodb/HaloDB.java
@@ -84,6 +84,15 @@ public final class HaloDB {
         return new HaloDBKeyIterator(dbInternal);
     }
 
+    /**
+     * Iterates, in ascending key order, the records whose key begins with {@code prefix}.
+     * Requires {@code HaloDBOptions.setUseOrderedIndex(true)} (with a fixed key size); otherwise
+     * throws {@link HaloDBException}.
+     */
+    public java.util.Iterator<Record> prefixScan(byte[] prefix) throws HaloDBException {
+        return dbInternal.prefixScan(prefix);
+    }
+
     public void pauseCompaction() throws HaloDBException {
         try {
             dbInternal.pauseCompaction();

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,7 +118,8 @@ class HaloDBInternal {
 
             dbInternal.inMemoryIndex = new InMemoryIndex(
                 options.getNumberOfRecords(), options.isUseMemoryPool(),
-                options.getFixedKeySize(), options.getMemoryPoolChunkSize()
+                options.getFixedKeySize(), options.getMemoryPoolChunkSize(),
+                options.isUseOrderedIndex()
             );
 
             long maxSequenceNumber = dbInternal.buildInMemoryIndex();
@@ -218,6 +220,9 @@ class HaloDBInternal {
     boolean put(byte[] key, byte[] value) throws IOException, HaloDBException {
         if (key.length > Byte.MAX_VALUE) {
             throw new HaloDBException("key length cannot exceed " + Byte.MAX_VALUE);
+        }
+        if (options.isUseOrderedIndex() && key.length != options.getFixedKeySize()) {
+            throw new HaloDBException("ordered index requires keys of exactly fixedKeySize (" + options.getFixedKeySize() + ") bytes");
         }
 
         //TODO: more fine-grained locking is possible. 
@@ -910,6 +915,47 @@ class HaloDBInternal {
         if (options.isUseMemoryPool() && (options.getFixedKeySize() < 0 || options.getFixedKeySize() > Byte.MAX_VALUE)) {
             throw new IllegalArgumentException("fixedKeySize must be set and should be less than 128 when using memory pool");
         }
+        if (options.isUseOrderedIndex() && (options.getFixedKeySize() <= 0 || options.getFixedKeySize() > Byte.MAX_VALUE)) {
+            throw new IllegalArgumentException("ordered index requires a fixedKeySize in (0, 127]; all keys must be exactly that length");
+        }
+    }
+
+    /**
+     * Iterates, in ascending key order, the records whose key begins with {@code prefix}. Requires
+     * the ordered index (HaloDBOptions.setUseOrderedIndex). The matching keys are snapshotted up
+     * front; each record's value is then read on demand. Keys deleted after the snapshot are skipped.
+     */
+    Iterator<Record> prefixScan(byte[] prefix) throws HaloDBException {
+        if (!inMemoryIndex.hasOrderedIndex()) {
+            throw new HaloDBException("prefixScan requires the ordered index; set HaloDBOptions.setUseOrderedIndex(true)");
+        }
+        List<byte[]> keys = inMemoryIndex.prefixScanKeys(prefix);
+        return new Iterator<Record>() {
+            int i = 0;
+            Record next = advance();
+
+            private Record advance() {
+                while (i < keys.size()) {
+                    byte[] k = keys.get(i++);
+                    try {
+                        byte[] v = get(k, 1);
+                        if (v != null) return new Record(k, v);
+                    } catch (IOException | HaloDBException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return null;
+            }
+
+            @Override public boolean hasNext() { return next != null; }
+
+            @Override public Record next() {
+                if (next == null) throw new java.util.NoSuchElementException();
+                Record r = next;
+                next = advance();
+                return r;
+            }
+        };
     }
 
     boolean isClosing() {

--- a/src/main/java/com/oath/halodb/HaloDBOptions.java
+++ b/src/main/java/com/oath/halodb/HaloDBOptions.java
@@ -41,6 +41,11 @@ public class HaloDBOptions implements Cloneable {
 
     private int memoryPoolChunkSize = 16 * 1024 * 1024;
 
+    // When true, maintains an ordered (off-heap ART) side index alongside the hash index to support
+    // prefix/range scans. Requires fixed-length keys (fixedKeySize). The hash index is unchanged, so
+    // point reads are unaffected; the cost is per-write side-index maintenance and ~2x index memory.
+    private boolean useOrderedIndex = false;
+
     // Number of threads to scan index and tombstone files
     // to build in-memory index at db open
     private int buildIndexThreads = 1;
@@ -157,6 +162,14 @@ public class HaloDBOptions implements Cloneable {
 
     public void setFixedKeySize(int fixedKeySize) {
         this.fixedKeySize = fixedKeySize;
+    }
+
+    public boolean isUseOrderedIndex() {
+        return useOrderedIndex;
+    }
+
+    public void setUseOrderedIndex(boolean useOrderedIndex) {
+        this.useOrderedIndex = useOrderedIndex;
     }
 
     public int getMemoryPoolChunkSize() {

--- a/src/main/java/com/oath/halodb/InMemoryIndex.java
+++ b/src/main/java/com/oath/halodb/InMemoryIndex.java
@@ -11,19 +11,40 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Hash table stored in native memory, outside Java heap.
+ *
+ * <p>When ordered indexing is enabled, an off-heap ART side index of the key set is maintained
+ * alongside the hash table to support prefix/range scans. The hash table remains the sole structure
+ * for point lookups, so reads are unaffected. The ART is single-writer (mutated only under the
+ * caller's write lock and the parallel open-build, both serialized here by {@link #orderedLock})
+ * and read by scans under the read lock — so node frees never race with a scan.
  */
 class InMemoryIndex {
     private static final Logger logger = LoggerFactory.getLogger(InMemoryIndex.class);
+    private static final byte[] EMPTY = new byte[0];
 
     private final OffHeapHashTable<InMemoryIndexMetaData> offHeapHashTable;
 
     private final int noOfSegments;
     private final int maxSizeOfEachSegment;
 
+    // Optional ordered side index (key set) for prefix/range scans.
+    private final OffHeapART orderedIndex;
+    private final ReadWriteLock orderedLock;
+
     InMemoryIndex(int numberOfKeys, boolean useMemoryPool, int fixedKeySize, int memoryPoolChunkSize) {
+        this(numberOfKeys, useMemoryPool, fixedKeySize, memoryPoolChunkSize, false);
+    }
+
+    InMemoryIndex(int numberOfKeys, boolean useMemoryPool, int fixedKeySize, int memoryPoolChunkSize, boolean useOrderedIndex) {
         noOfSegments = Ints.checkedCast(Utils.roundUpToPowerOf2(Runtime.getRuntime().availableProcessors() * 2));
         maxSizeOfEachSegment = Ints.checkedCast(Utils.roundUpToPowerOf2(numberOfKeys / noOfSegments));
         long start = System.currentTimeMillis();
@@ -41,19 +62,72 @@ class InMemoryIndex {
 
         this.offHeapHashTable = builder.build();
 
+        if (useOrderedIndex) {
+            this.orderedIndex = new OffHeapART(fixedKeySize, 0); // key-only side index
+            this.orderedLock = new ReentrantReadWriteLock();
+        } else {
+            this.orderedIndex = null;
+            this.orderedLock = null;
+        }
+
         logger.debug("Allocated memory for the index in {}", (System.currentTimeMillis() - start));
     }
 
+    boolean hasOrderedIndex() {
+        return orderedIndex != null;
+    }
+
+    private void orderedAdd(byte[] key) {
+        orderedLock.writeLock().lock();
+        try {
+            orderedIndex.put(key, EMPTY); // idempotent: no-op if the key is already present
+        } finally {
+            orderedLock.writeLock().unlock();
+        }
+    }
+
+    private void orderedRemove(byte[] key) {
+        orderedLock.writeLock().lock();
+        try {
+            orderedIndex.remove(key);
+        } finally {
+            orderedLock.writeLock().unlock();
+        }
+    }
+
     boolean put(byte[] key, InMemoryIndexMetaData metaData) {
-        return offHeapHashTable.put(key, metaData);
+        boolean r = offHeapHashTable.put(key, metaData);
+        if (orderedIndex != null) orderedAdd(key);
+        return r;
     }
 
     boolean putIfAbsent(byte[] key, InMemoryIndexMetaData metaData) {
-        return offHeapHashTable.putIfAbsent(key, metaData);
+        boolean r = offHeapHashTable.putIfAbsent(key, metaData);
+        if (orderedIndex != null) orderedAdd(key);
+        return r;
     }
 
     boolean remove(byte[] key) {
-        return offHeapHashTable.remove(key);
+        boolean r = offHeapHashTable.remove(key);
+        if (orderedIndex != null) orderedRemove(key);
+        return r;
+    }
+
+    /**
+     * Collects, in ascending key order, the keys with the given prefix — a snapshot taken under the
+     * read lock (in-memory only; the lock is not held while the caller subsequently reads records).
+     */
+    List<byte[]> prefixScanKeys(byte[] prefix) {
+        if (orderedIndex == null) throw new IllegalStateException("ordered index is not enabled");
+        List<byte[]> keys = new ArrayList<>();
+        orderedLock.readLock().lock();
+        try {
+            Iterator<byte[]> it = orderedIndex.prefixScan(prefix);
+            while (it.hasNext()) keys.add(it.next());
+        } finally {
+            orderedLock.readLock().unlock();
+        }
+        return Collections.unmodifiableList(keys);
     }
 
     boolean replace(byte[] key, InMemoryIndexMetaData oldValue, InMemoryIndexMetaData newValue) {
@@ -73,6 +147,14 @@ class InMemoryIndex {
             offHeapHashTable.close();
         } catch (IOException e) {
             e.printStackTrace();
+        }
+        if (orderedIndex != null) {
+            orderedLock.writeLock().lock();
+            try {
+                orderedIndex.close();
+            } finally {
+                orderedLock.writeLock().unlock();
+            }
         }
     }
 

--- a/src/main/java/com/oath/halodb/OffHeapART.java
+++ b/src/main/java/com/oath/halodb/OffHeapART.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright 2018, Oath Inc
+ * Licensed under the terms of the Apache License 2.0. Please refer to accompanying LICENSE file for terms.
+ */
+
+package com.oath.halodb;
+
+import java.lang.invoke.VarHandle;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Pointer-tagged off-heap ART (fixed-length keys). Each stored child pointer carries the pointee's
+ * node type in its low 3 bits (allocations are >=8-aligned), so navigation never loads a node's type
+ * byte or branches on a loaded value — the type is known from the tag already in hand. This targets
+ * the per-hop dispatch overhead that separates real ART (~235ns) from the dispatch-free proxy
+ * (~125ns, which beat the hash).
+ *
+ * Node types N4/N16/N256 (Node48 dropped); lazy leaves; no path compression / delete yet. Header
+ * byte still stores the type code (== tag) for scan/close, which aren't on the hot path.
+ *
+ * Tagged pointer = address | type, where type in {LEAF=1, N4=2, N16=3, N256=4}; 0 = empty slot.
+ */
+final class OffHeapART {
+
+    private static final int LEAF = 1, N4 = 2, N16 = 3, N256 = 4;
+    private static final long MASK = ~7L;
+    private static final long ONES = 0x0101010101010101L;
+    private static final long HIGHS = 0x8080808080808080L;
+
+    private final int keyLen;
+    private final int valueSize;
+    private long root = 0; // tagged pointer, 0 = empty tree
+    private long size = 0;
+    private volatile boolean closed = false;
+
+    OffHeapART(int keyLen, int valueSize) {
+        this.keyLen = keyLen;
+        this.valueSize = valueSize;
+    }
+
+    private long nodeSize(int type) {
+        switch (type) {
+            case N4:   return 16 + 4L * 8;
+            case N16:  return 24 + 16L * 8;
+            case N256: return 8 + 256L * 8;
+            case LEAF: return 8 + keyLen + valueSize;
+            default: throw new IllegalStateException();
+        }
+    }
+
+    private long newNode(int type) {
+        long s = nodeSize(type);
+        long n = Uns.allocate(s, true);
+        Uns.setMemory(n, 0, s, (byte) 0);
+        Uns.putByte(n, 0, (byte) type);
+        return n; // untagged
+    }
+
+    private long newLeaf(byte[] key, byte[] value) {
+        long n = Uns.allocate(8 + keyLen + valueSize, true);
+        Uns.putByte(n, 0, (byte) LEAF);
+        Uns.copyMemory(key, 0, n, 8, keyLen);
+        Uns.copyMemory(value, 0, n, 8L + keyLen, valueSize);
+        return n; // untagged
+    }
+
+    private static int hdrType(long node) { return Uns.getByte(node, 0) & 0xFF; }
+    private static int count(long n) { return Uns.getInt(n, 4); }
+    private static void setCount(long n, int c) { Uns.putInt(n, 4, c); }
+
+    private static long n4Key(int i) { return 8 + i; }
+    private static long n4Child(int i) { return 16 + 8L * i; }
+    private static long n16Child(int i) { return 24 + 8L * i; }
+    private static long n256Child(int b) { return 8 + 8L * b; }
+
+    private boolean leafKeyEquals(long leaf, byte[] key) {
+        for (int i = 0; i < keyLen; i++) if (Uns.getByte(leaf, 8 + i) != key[i]) return false;
+        return true;
+    }
+
+    private byte[] leafKey(long leaf) {
+        byte[] k = new byte[keyLen];
+        Uns.copyMemory(leaf, 8, k, 0, keyLen);
+        return k;
+    }
+
+    /** Returns the stored tagged child for byte b, or 0. type is the (already-known) tag of node. */
+    private long findChildTagged(long node, int type, int b) {
+        switch (type) {
+            case N4: {
+                int c = count(node);
+                for (int i = 0; i < c; i++) if ((Uns.getByte(node, n4Key(i)) & 0xFF) == b) return Uns.getLong(node, n4Child(i));
+                return 0;
+            }
+            case N16: {
+                int c = count(node);
+                long bc = (b & 0xFFL) * ONES;
+                long x0 = Uns.getLong(node, 8) ^ bc;
+                long m0 = (x0 - ONES) & ~x0 & HIGHS;
+                if (m0 != 0) { int lane = Long.numberOfTrailingZeros(m0) >>> 3; if (lane < c) return Uns.getLong(node, n16Child(lane)); }
+                if (c > 8) {
+                    long x1 = Uns.getLong(node, 16) ^ bc;
+                    long m1 = (x1 - ONES) & ~x1 & HIGHS;
+                    if (m1 != 0) { int idx = 8 + (Long.numberOfTrailingZeros(m1) >>> 3); if (idx < c) return Uns.getLong(node, n16Child(idx)); }
+                }
+                return 0;
+            }
+            case N256:
+                return Uns.getLong(node, n256Child(b));
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    boolean get(byte[] key, byte[] dst) {
+        ensureOpen();
+        long cur = root;
+        if (cur == 0) return false;
+        int depth = 0;
+        int t;
+        while ((t = (int) (cur & 7)) != LEAF) {
+            long node = cur & MASK;
+            int b = key[depth] & 0xFF;
+            // Inline the Node256 fast path (the common hop for dense trees); method-call only for N4/N16.
+            cur = (t == N256) ? Uns.getLong(node, 8 + 8L * b) : findChildTagged(node, t, b);
+            if (cur == 0) return false;
+            depth++;
+        }
+        long leaf = cur & MASK;
+        if (leafKeyEquals(leaf, key)) {
+            Uns.copyMemory(leaf, 8L + keyLen, dst, 0, valueSize);
+            return true;
+        }
+        return false;
+    }
+
+    boolean contains(byte[] key) {
+        ensureOpen();
+        long cur = root;
+        if (cur == 0) return false;
+        int depth = 0;
+        while (((int) (cur & 7)) != LEAF) {
+            cur = findChildTagged(cur & MASK, (int) (cur & 7), key[depth] & 0xFF);
+            if (cur == 0) return false;
+            depth++;
+        }
+        return leafKeyEquals(cur & MASK, key);
+    }
+
+    boolean put(byte[] key, byte[] value) {
+        ensureOpen();
+        if (root == 0) {
+            root = newLeaf(key, value) | LEAF;
+            size++;
+            return true;
+        }
+        long parent = 0;
+        int parentByte = -1, depth = 0;
+        boolean parentIsRoot = true;
+        long cur = root;
+        while (true) {
+            int t = (int) (cur & 7);
+            if (t == LEAF) {
+                long leaf = cur & MASK;
+                if (leafKeyEquals(leaf, key)) { Uns.copyMemory(value, 0, leaf, 8L + keyLen, valueSize); return false; }
+                long sub = buildSplit(leaf, leafKey(leaf), key, newLeaf(key, value), depth);
+                long tagged = sub | N4;
+                if (parentIsRoot) root = tagged; else replaceChild(parent, parentByte, tagged);
+                size++;
+                return true;
+            }
+            long node = cur & MASK;
+            int b = key[depth] & 0xFF;
+            long child = findChildTagged(node, t, b);
+            if (child == 0) {
+                long grown = addChild(node, t, b, newLeaf(key, value) | LEAF);
+                if (grown != node) {
+                    long tg = grown | hdrType(grown);
+                    if (parentIsRoot) root = tg; else replaceChild(parent, parentByte, tg);
+                }
+                size++;
+                return true;
+            }
+            parent = node;
+            parentByte = b;
+            parentIsRoot = false;
+            cur = child;
+            depth++;
+        }
+    }
+
+    /**
+     * Removes a key. Unlinks its leaf and frees it; does not merge/shrink under-full inner nodes
+     * (correct, just not maximally compact — fine for a side index). Frees immediately, which is safe
+     * because callers serialize remove with scans (a scan holds the read side of the index lock).
+     */
+    boolean remove(byte[] key) {
+        ensureOpen();
+        if (root == 0) return false;
+        long parentNode = 0;
+        int parentByte = -1;
+        long cur = root;
+        int depth = 0;
+        while (true) {
+            int t = (int) (cur & 7);
+            if (t == LEAF) {
+                long leaf = cur & MASK;
+                if (!leafKeyEquals(leaf, key)) return false;
+                if (parentNode == 0) root = 0; // leaf was the root
+                else removeChild(parentNode, parentByte);
+                Uns.free(leaf);
+                size--;
+                return true;
+            }
+            long node = cur & MASK;
+            int b = key[depth] & 0xFF;
+            long child = findChildTagged(node, t, b);
+            if (child == 0) return false;
+            parentNode = node;
+            parentByte = b;
+            cur = child;
+            depth++;
+        }
+    }
+
+    private void removeChild(long node, int b) {
+        switch (hdrType(node)) {
+            case N4: {
+                int c = count(node);
+                for (int i = 0; i < c; i++) {
+                    if ((Uns.getByte(node, n4Key(i)) & 0xFF) == b) {
+                        for (int j = i; j < c - 1; j++) {
+                            Uns.putByte(node, n4Key(j), Uns.getByte(node, n4Key(j + 1)));
+                            Uns.putLong(node, n4Child(j), Uns.getLong(node, n4Child(j + 1)));
+                        }
+                        setCount(node, c - 1);
+                        return;
+                    }
+                }
+                return;
+            }
+            case N16: {
+                int c = count(node);
+                for (int i = 0; i < c; i++) {
+                    if ((Uns.getByte(node, 8 + i) & 0xFF) == b) {
+                        for (int j = i; j < c - 1; j++) {
+                            Uns.putByte(node, 8 + j, Uns.getByte(node, 8 + (j + 1)));
+                            Uns.putLong(node, n16Child(j), Uns.getLong(node, n16Child(j + 1)));
+                        }
+                        setCount(node, c - 1);
+                        return;
+                    }
+                }
+                return;
+            }
+            case N256:
+                Uns.putLong(node, n256Child(b), 0);
+                setCount(node, count(node) - 1);
+                return;
+        }
+    }
+
+    private long buildSplit(long eLeaf, byte[] ek, byte[] nk, long nLeaf, int from) {
+        int d = from;
+        while (d < keyLen && ek[d] == nk[d]) d++;
+        long div = newNode(N4);
+        addChild(div, N4, ek[d] & 0xFF, eLeaf | LEAF);
+        addChild(div, N4, nk[d] & 0xFF, nLeaf | LEAF);
+        long top = div;
+        for (int level = d - 1; level >= from; level--) {
+            long n = newNode(N4);
+            addChild(n, N4, ek[level] & 0xFF, top | N4);
+            top = n;
+        }
+        return top;
+    }
+
+    /** Adds taggedChild for byte b; may grow node, returning the (possibly new) untagged node. */
+    private long addChild(long node, int type, int b, long taggedChild) {
+        switch (type) {
+            case N4: {
+                int c = count(node);
+                if (c < 4) { insertSortedN4(node, b, taggedChild, c); return node; }
+                return addChild(growN4toN16(node), N16, b, taggedChild);
+            }
+            case N16: {
+                int c = count(node);
+                if (c < 16) { insertSortedN16(node, b, taggedChild, c); return node; }
+                return addChild(growN16toN256(node), N256, b, taggedChild);
+            }
+            case N256: {
+                VarHandle.releaseFence();
+                Uns.putLong(node, n256Child(b), taggedChild);
+                setCount(node, count(node) + 1);
+                return node;
+            }
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    private void insertSortedN4(long node, int b, long taggedChild, int c) {
+        int pos = 0;
+        while (pos < c && (Uns.getByte(node, n4Key(pos)) & 0xFF) < b) pos++;
+        for (int i = c; i > pos; i--) {
+            Uns.putByte(node, n4Key(i), Uns.getByte(node, n4Key(i - 1)));
+            Uns.putLong(node, n4Child(i), Uns.getLong(node, n4Child(i - 1)));
+        }
+        Uns.putByte(node, n4Key(pos), (byte) b);
+        VarHandle.releaseFence();
+        Uns.putLong(node, n4Child(pos), taggedChild);
+        setCount(node, c + 1);
+    }
+
+    private void insertSortedN16(long node, int b, long taggedChild, int c) {
+        int pos = 0;
+        while (pos < c && (Uns.getByte(node, 8 + pos) & 0xFF) < b) pos++;
+        for (int i = c; i > pos; i--) {
+            Uns.putByte(node, 8 + i, Uns.getByte(node, 8 + (i - 1)));
+            Uns.putLong(node, n16Child(i), Uns.getLong(node, n16Child(i - 1)));
+        }
+        Uns.putByte(node, 8 + pos, (byte) b);
+        VarHandle.releaseFence();
+        Uns.putLong(node, n16Child(pos), taggedChild);
+        setCount(node, c + 1);
+    }
+
+    private long growN4toN16(long node) {
+        long m = newNode(N16);
+        int c = count(node);
+        for (int i = 0; i < c; i++) {
+            Uns.putByte(m, 8 + i, Uns.getByte(node, n4Key(i)));
+            Uns.putLong(m, n16Child(i), Uns.getLong(node, n4Child(i)));
+        }
+        setCount(m, c);
+        Uns.free(node);
+        return m;
+    }
+
+    private long growN16toN256(long node) {
+        long m = newNode(N256);
+        int c = count(node);
+        for (int i = 0; i < c; i++) {
+            int kb = Uns.getByte(node, 8 + i) & 0xFF;
+            Uns.putLong(m, n256Child(kb), Uns.getLong(node, n16Child(i)));
+        }
+        setCount(m, c);
+        Uns.free(node);
+        return m;
+    }
+
+    private void replaceChild(long node, int b, long taggedChild) {
+        int type = hdrType(node);
+        switch (type) {
+            case N4: {
+                int c = count(node);
+                for (int i = 0; i < c; i++) if ((Uns.getByte(node, n4Key(i)) & 0xFF) == b) { Uns.putLong(node, n4Child(i), taggedChild); return; }
+                break;
+            }
+            case N16: {
+                int c = count(node);
+                for (int i = 0; i < c; i++) if ((Uns.getByte(node, 8 + i) & 0xFF) == b) { Uns.putLong(node, n16Child(i), taggedChild); return; }
+                break;
+            }
+            case N256:
+                Uns.putLong(node, n256Child(b), taggedChild);
+                return;
+        }
+        throw new IllegalStateException("replaceChild: byte not present");
+    }
+
+    long size() { return size; }
+
+    // ---- ordered scan (uses header type; not hot path) ----
+    private int nextChildByte(long node, int from) {
+        switch (hdrType(node)) {
+            case N4: {
+                int c = count(node), best = 256;
+                for (int i = 0; i < c; i++) { int kb = Uns.getByte(node, n4Key(i)) & 0xFF; if (kb >= from && kb < best) best = kb; }
+                return best;
+            }
+            case N16: {
+                int c = count(node), best = 256;
+                for (int i = 0; i < c; i++) { int kb = Uns.getByte(node, 8 + i) & 0xFF; if (kb >= from && kb < best) best = kb; }
+                return best;
+            }
+            case N256:
+                for (int b = from; b < 256; b++) if (Uns.getLong(node, n256Child(b)) != 0) return b;
+                return 256;
+            default:
+                return 256;
+        }
+    }
+
+    Iterator<byte[]> scan(byte[] startInclusive, byte[] endExclusive) {
+        ensureOpen();
+        return new Iterator<>() {
+            final long[] sn = new long[keyLen + 2];
+            final int[] sc = new int[keyLen + 2];
+            int sp = -1;
+            boolean started = false, done = false;
+            byte[] pending = init();
+
+            private byte[] init() {
+                if (root == 0) return null;
+                if ((root & 7) == LEAF) { done = true; return accept(leafKey(root & MASK)); }
+                sp = 0; sn[0] = root & MASK; sc[0] = 0;
+                return advance();
+            }
+
+            private byte[] accept(byte[] k) {
+                if (startInclusive != null && cmp(k, startInclusive) < 0) return null;
+                if (endExclusive != null && cmp(k, endExclusive) >= 0) { done = true; sp = -1; return null; }
+                return k;
+            }
+
+            private byte[] advance() {
+                while (sp >= 0) {
+                    long node = sn[sp];
+                    int b = nextChildByte(node, sc[sp]);
+                    if (b > 255) { sp--; continue; }
+                    sc[sp] = b + 1;
+                    long child = findChildTagged(node, hdrType(node), b);
+                    if ((child & 7) == LEAF) {
+                        byte[] k = accept(leafKey(child & MASK));
+                        if (k != null) return k;
+                        if (done) return null;
+                        continue;
+                    }
+                    sp++; sn[sp] = child & MASK; sc[sp] = 0;
+                }
+                return null;
+            }
+
+            @Override public boolean hasNext() { return pending != null; }
+
+            @Override public byte[] next() {
+                if (pending == null) throw new NoSuchElementException();
+                byte[] k = pending;
+                pending = done ? null : advance();
+                return k;
+            }
+        };
+    }
+
+    Iterator<byte[]> prefixScan(byte[] prefix) {
+        return scan(prefix, OrderedKeyIndex.prefixUpperBound(prefix));
+    }
+
+    private static int cmp(byte[] a, byte[] b) {
+        int min = Math.min(a.length, b.length);
+        for (int i = 0; i < min; i++) { int x = a[i] & 0xFF, y = b[i] & 0xFF; if (x != y) return x - y; }
+        return a.length - b.length;
+    }
+
+    void close() {
+        if (closed) return;
+        closed = true;
+        if (root != 0) freeRec(root);
+    }
+
+    private void freeRec(long tagged) {
+        long node = tagged & MASK;
+        if ((tagged & 7) != LEAF) {
+            int b = nextChildByte(node, 0);
+            while (b <= 255) { freeRec(findChildTagged(node, hdrType(node), b)); b = nextChildByte(node, b + 1); }
+        }
+        Uns.free(node);
+    }
+
+    private void ensureOpen() {
+        if (closed) throw new IllegalStateException("OffHeapART is closed");
+    }
+}

--- a/src/main/java/com/oath/halodb/OffHeapART.java
+++ b/src/main/java/com/oath/halodb/OffHeapART.java
@@ -444,8 +444,73 @@ final class OffHeapART {
         };
     }
 
+    /**
+     * Iterates, in ascending order, every key beginning with {@code prefix}. Seeks directly to the
+     * subtree rooted at the prefix path — O(prefix length + matches) — rather than scanning from the
+     * start of the keyspace. Every leaf under that subtree shares the prefix by construction, so no
+     * per-key filtering is needed.
+     */
     Iterator<byte[]> prefixScan(byte[] prefix) {
-        return scan(prefix, OrderedKeyIndex.prefixUpperBound(prefix));
+        ensureOpen();
+        if (root == 0) return java.util.Collections.emptyIterator();
+        long node = root;
+        int depth = 0;
+        while (depth < prefix.length && ((int) (node & 7)) != LEAF) {
+            node = findChildTagged(node & MASK, (int) (node & 7), prefix[depth] & 0xFF);
+            if (node == 0) return java.util.Collections.emptyIterator();
+            depth++;
+        }
+        if (((int) (node & 7)) == LEAF) {
+            // a lazy leaf short-circuited the descent; include it only if it actually matches
+            long leaf = node & MASK;
+            return keyHasPrefix(leaf, prefix)
+                ? java.util.List.of(leafKey(leaf)).iterator()
+                : java.util.Collections.emptyIterator();
+        }
+        return subtreeLeaves(node); // every leaf under here has the prefix
+    }
+
+    private boolean keyHasPrefix(long leaf, byte[] prefix) {
+        for (int i = 0; i < prefix.length; i++) if (Uns.getByte(leaf, 8 + i) != prefix[i]) return false;
+        return true;
+    }
+
+    /** DFS over a subtree (tagged node), yielding every leaf key in ascending order. */
+    private Iterator<byte[]> subtreeLeaves(long subtreeRootTagged) {
+        return new Iterator<>() {
+            final long[] sn = new long[keyLen + 2];
+            final int[] sc = new int[keyLen + 2];
+            int sp = 0;
+            byte[] pending;
+
+            {
+                sn[0] = subtreeRootTagged & MASK;
+                sc[0] = 0;
+                pending = advance();
+            }
+
+            private byte[] advance() {
+                while (sp >= 0) {
+                    long n = sn[sp];
+                    int b = nextChildByte(n, sc[sp]);
+                    if (b > 255) { sp--; continue; }
+                    sc[sp] = b + 1;
+                    long child = findChildTagged(n, hdrType(n), b);
+                    if ((child & 7) == LEAF) return leafKey(child & MASK);
+                    sp++; sn[sp] = child & MASK; sc[sp] = 0;
+                }
+                return null;
+            }
+
+            @Override public boolean hasNext() { return pending != null; }
+
+            @Override public byte[] next() {
+                if (pending == null) throw new NoSuchElementException();
+                byte[] k = pending;
+                pending = advance();
+                return k;
+            }
+        };
     }
 
     private static int cmp(byte[] a, byte[] b) {

--- a/src/main/java/com/oath/halodb/OrderedKeyIndex.java
+++ b/src/main/java/com/oath/halodb/OrderedKeyIndex.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018, Oath Inc
+ * Licensed under the terms of the Apache License 2.0. Please refer to accompanying LICENSE file for terms.
+ */
+
+package com.oath.halodb;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+/**
+ * An ordered set of keys kept in native (off-heap) memory, used only to support prefix/range scans.
+ *
+ * <p>This sits <em>alongside</em> HaloDB's hash index (it does not replace it): point gets,
+ * {@code isRecordFresh}, and full-scan iteration keep using the hash table, so existing read paths
+ * are unaffected. Only the write path (and only when ordered indexing is enabled) maintains this
+ * structure. Keys are compared as unsigned-byte lexicographic strings, which is the order a prefix
+ * scan walks.
+ *
+ * <p>Concurrency model is single-writer / multi-reader: HaloDB serializes writes through one write
+ * lock, so {@link #add}/{@link #remove} are never called concurrently with each other, while
+ * {@link #contains}/{@link #scan} may run concurrently with a writer.
+ */
+interface OrderedKeyIndex extends Closeable {
+
+    /** Adds the key. Returns true if it was newly added, false if it was already present. */
+    boolean add(byte[] key);
+
+    /** Removes the key. Returns true if it was present. */
+    boolean remove(byte[] key);
+
+    boolean contains(byte[] key);
+
+    long size();
+
+    /**
+     * Iterates keys in ascending unsigned-byte order within [startInclusive, endExclusive).
+     * A null end means "to the end". The returned keys are fresh copies.
+     */
+    Iterator<byte[]> scan(byte[] startInclusive, byte[] endExclusive);
+
+    /** Iterates, in order, every key that begins with {@code prefix}. */
+    default Iterator<byte[]> prefixScan(byte[] prefix) {
+        return scan(prefix, prefixUpperBound(prefix));
+    }
+
+    /**
+     * The smallest key that is strictly greater than every key starting with {@code prefix} — i.e.
+     * the exclusive upper bound for a prefix scan. Returns null when the prefix is all 0xFF bytes
+     * (no upper bound; scan runs to the end).
+     */
+    static byte[] prefixUpperBound(byte[] prefix) {
+        for (int i = prefix.length - 1; i >= 0; i--) {
+            int b = prefix[i] & 0xFF;
+            if (b != 0xFF) {
+                byte[] bound = new byte[i + 1];
+                System.arraycopy(prefix, 0, bound, 0, i + 1);
+                bound[i] = (byte) (b + 1);
+                return bound;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/oath/halodb/HaloDBPrefixScanTest.java
+++ b/src/test/java/com/oath/halodb/HaloDBPrefixScanTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018, Oath Inc
+ * Licensed under the terms of the Apache License 2.0. Please refer to accompanying LICENSE file for terms.
+ */
+
+package com.oath.halodb;
+
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class HaloDBPrefixScanTest extends TestBase {
+
+    private static final int KEY_SIZE = 8;
+
+    private static byte[] key(Random r, int category) {
+        byte[] k = new byte[KEY_SIZE];
+        r.nextBytes(k);
+        k[0] = (byte) category; // first byte = prefix/category
+        return k;
+    }
+
+    private static String s(byte[] b) { return new String(b, StandardCharsets.ISO_8859_1); }
+
+    private static HaloDBOptions orderedOptions() {
+        HaloDBOptions o = new HaloDBOptions();
+        o.setUseOrderedIndex(true);
+        o.setFixedKeySize(KEY_SIZE);
+        o.setCompactionDisabled(true); // keep the test deterministic
+        return o;
+    }
+
+    private List<byte[]> scanKeys(HaloDB db, byte[] prefix) throws Exception {
+        List<byte[]> out = new ArrayList<>();
+        Iterator<Record> it = db.prefixScan(prefix);
+        byte[] prev = null;
+        while (it.hasNext()) {
+            Record rec = it.next();
+            byte[] k = rec.getKey();
+            // returned key actually has the prefix, and order is strictly ascending
+            assertTrue(s(k).startsWith(s(prefix)), "key lacks prefix");
+            if (prev != null) assertTrue(s(prev).compareTo(s(k)) < 0, "not ascending");
+            prev = k;
+            out.add(k);
+        }
+        return out;
+    }
+
+    private static List<String> oracleKeys(TreeMap<String, byte[]> oracle, byte[] prefix) {
+        List<String> out = new ArrayList<>();
+        String p = s(prefix);
+        for (String k : oracle.keySet()) if (k.startsWith(p)) out.add(k);
+        return out;
+    }
+
+    @Test
+    public void testPrefixScanAgainstOracle() throws Exception {
+        String dir = TestUtils.getTestDirectory("HaloDBPrefixScanTest", "scan");
+        HaloDB db = getTestDB(dir, orderedOptions());
+        Random r = new Random(1);
+        TreeMap<String, byte[]> oracle = new TreeMap<>();
+        for (int i = 0; i < 20_000; i++) {
+            byte[] k = key(r, i % 5);
+            byte[] v = ("v" + i).getBytes();
+            db.put(k, v);
+            oracle.put(s(k), v);
+        }
+        for (int cat = 0; cat < 6; cat++) { // 0..4 present, 5 absent
+            byte[] prefix = {(byte) cat};
+            List<byte[]> got = scanKeys(db, prefix);
+            List<String> expected = oracleKeys(oracle, prefix);
+            assertEquals(got.size(), expected.size(), "count for category " + cat);
+            for (int i = 0; i < got.size(); i++) assertEquals(s(got.get(i)), expected.get(i));
+        }
+        // empty prefix scans everything in order
+        assertEquals(scanKeys(db, new byte[0]).size(), oracle.size());
+    }
+
+    @Test
+    public void testPrefixScanReflectsDeletes() throws Exception {
+        String dir = TestUtils.getTestDirectory("HaloDBPrefixScanTest", "deletes");
+        HaloDB db = getTestDB(dir, orderedOptions());
+        Random r = new Random(2);
+        TreeMap<String, byte[]> oracle = new TreeMap<>();
+        List<byte[]> keys = new ArrayList<>();
+        for (int i = 0; i < 5_000; i++) {
+            byte[] k = key(r, 0);
+            db.put(k, ("v" + i).getBytes());
+            oracle.put(s(k), null);
+            keys.add(k);
+        }
+        for (int i = 0; i < keys.size(); i += 3) {
+            db.delete(keys.get(i));
+            oracle.remove(s(keys.get(i)));
+        }
+        List<byte[]> got = scanKeys(db, new byte[]{0});
+        assertEquals(got.size(), oracle.size());
+        for (int i = 0; i < got.size(); i++) assertEquals(s(got.get(i)), new ArrayList<>(oracle.keySet()).get(i));
+    }
+
+    @Test
+    public void testPrefixScanSurvivesReopen() throws Exception {
+        String dir = TestUtils.getTestDirectory("HaloDBPrefixScanTest", "reopen");
+        HaloDB db = getTestDB(dir, orderedOptions());
+        Random r = new Random(3);
+        TreeMap<String, byte[]> oracle = new TreeMap<>();
+        for (int i = 0; i < 10_000; i++) {
+            byte[] k = key(r, i % 3);
+            db.put(k, ("v" + i).getBytes());
+            oracle.put(s(k), null);
+        }
+        db.close();
+        // reopen: the ordered index must be rebuilt from the index files during open
+        db = getTestDBWithoutDeletingFiles(dir, orderedOptions());
+        byte[] prefix = {1};
+        List<byte[]> got = scanKeys(db, prefix);
+        List<String> expected = oracleKeys(oracle, prefix);
+        assertEquals(got.size(), expected.size());
+        for (int i = 0; i < got.size(); i++) assertEquals(s(got.get(i)), expected.get(i));
+    }
+
+    @Test
+    public void testPrefixScanThrowsWhenDisabled() throws Exception {
+        String dir = TestUtils.getTestDirectory("HaloDBPrefixScanTest", "disabled");
+        HaloDB db = getTestDB(dir, new HaloDBOptions()); // ordered index off
+        db.put("12345678".getBytes(), "v".getBytes());
+        try {
+            db.prefixScan(new byte[]{(byte) '1'});
+            fail("expected HaloDBException when ordered index is disabled");
+        } catch (HaloDBException expected) {
+            // ok
+        }
+    }
+}

--- a/src/test/java/com/oath/halodb/OffHeapARTTest.java
+++ b/src/test/java/com/oath/halodb/OffHeapARTTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2018, Oath Inc
+ * Licensed under the terms of the Apache License 2.0. Please refer to accompanying LICENSE file for terms.
+ */
+
+package com.oath.halodb;
+
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class OffHeapARTTest {
+
+    private static final Comparator<byte[]> CMP = (a, b) -> {
+        int min = Math.min(a.length, b.length);
+        for (int i = 0; i < min; i++) { int x = a[i] & 0xFF, y = b[i] & 0xFF; if (x != y) return x - y; }
+        return a.length - b.length;
+    };
+
+    private static byte[] randomKey(Random r, int len) {
+        byte[] k = new byte[len];
+        for (int i = 0; i < len; i++) k[i] = (byte) (i < len / 2 ? r.nextInt(6) : r.nextInt(256));
+        return k;
+    }
+
+    private static byte[] randomValue(Random r, int len) { byte[] v = new byte[len]; r.nextBytes(v); return v; }
+
+    private static List<byte[]> toList(Iterator<byte[]> it) {
+        List<byte[]> out = new ArrayList<>();
+        while (it.hasNext()) out.add(it.next());
+        return out;
+    }
+
+    private static void assertSameOrder(List<byte[]> expected, List<byte[]> actual) {
+        assertEquals(actual.size(), expected.size());
+        for (int i = 0; i < expected.size(); i++) assertEquals(actual.get(i), expected.get(i));
+    }
+
+    @Test
+    public void testGrowthThroughNodeTypes() {
+        OffHeapART art = new OffHeapART(4, 8);
+        byte[] dst = new byte[8];
+        try {
+            for (int b = 0; b < 256; b++) art.put(new byte[]{0, 0, 0, (byte) b}, new byte[]{(byte) b, 1, 2, 3, 4, 5, 6, 7});
+            assertEquals(art.size(), 256L);
+            for (int b = 0; b < 256; b++) {
+                assertTrue(art.get(new byte[]{0, 0, 0, (byte) b}, dst));
+                assertEquals(dst[0], (byte) b);
+            }
+            List<byte[]> scanned = toList(art.scan(null, null));
+            assertEquals(scanned.size(), 256);
+            for (int i = 0; i < 256; i++) assertEquals(scanned.get(i)[3] & 0xFF, i);
+        } finally {
+            art.close();
+        }
+    }
+
+    @Test
+    public void testRandomAgainstOracle() {
+        int keyLen = 4, vsize = 8;
+        Random r = new Random(42);
+        TreeMap<byte[], byte[]> oracle = new TreeMap<>(CMP);
+        OffHeapART art = new OffHeapART(keyLen, vsize);
+        byte[] dst = new byte[vsize];
+        try {
+            for (int i = 0; i < 50_000; i++) {
+                byte[] k = randomKey(r, keyLen);
+                byte[] v = randomValue(r, vsize);
+                assertEquals(art.put(k, v), oracle.put(k, v) == null);
+            }
+            assertEquals(art.size(), (long) oracle.size());
+            for (Map.Entry<byte[], byte[]> e : oracle.entrySet()) {
+                assertTrue(art.get(e.getKey(), dst));
+                assertEquals(dst, e.getValue());
+            }
+            for (int i = 0; i < 10_000; i++) {
+                byte[] k = randomKey(r, keyLen);
+                assertEquals(art.contains(k), oracle.containsKey(k));
+            }
+            assertSameOrder(new ArrayList<>(oracle.keySet()), toList(art.scan(null, null)));
+        } finally {
+            art.close();
+        }
+    }
+
+    @Test
+    public void testPrefixAndRangeScan() {
+        int keyLen = 4, vsize = 4;
+        Random r = new Random(99);
+        TreeMap<byte[], byte[]> oracle = new TreeMap<>(CMP);
+        OffHeapART art = new OffHeapART(keyLen, vsize);
+        try {
+            for (int i = 0; i < 30_000; i++) {
+                byte[] k = randomKey(r, keyLen);
+                byte[] v = randomValue(r, vsize);
+                art.put(k, v);
+                oracle.put(k, v);
+            }
+            byte[][] prefixes = {{}, {0}, {3}, {1, 2}, {0, 0}, {5, 5, 5}, {9}};
+            for (byte[] prefix : prefixes) {
+                List<byte[]> expected = new ArrayList<>();
+                for (byte[] k : oracle.keySet()) if (startsWith(k, prefix)) expected.add(k);
+                assertSameOrder(expected, toList(art.prefixScan(prefix)));
+            }
+            byte[] start = {1, 0, 0, 0}, end = {4, 0, 0, 0};
+            List<byte[]> expected = new ArrayList<>(oracle.subMap(start, true, end, false).keySet());
+            assertSameOrder(expected, toList(art.scan(start, end)));
+        } finally {
+            art.close();
+        }
+    }
+
+    @Test
+    public void testEightByteKeysOverwrite() {
+        OffHeapART art = new OffHeapART(8, 20);
+        Random r = new Random(5);
+        TreeMap<byte[], byte[]> oracle = new TreeMap<>(CMP);
+        byte[] dst = new byte[20];
+        try {
+            for (int i = 0; i < 40_000; i++) {
+                byte[] k = new byte[8];
+                r.nextBytes(k);
+                byte[] v = randomValue(r, 20);
+                art.put(k, v);
+                oracle.put(k, v);
+            }
+            assertEquals(art.size(), (long) oracle.size());
+            for (Map.Entry<byte[], byte[]> e : oracle.entrySet()) {
+                assertTrue(art.get(e.getKey(), dst));
+                assertEquals(dst, e.getValue());
+            }
+            byte[] k0 = oracle.firstKey();
+            byte[] nv = new byte[20];
+            nv[0] = 77;
+            assertFalse(art.put(k0, nv));
+            assertTrue(art.get(k0, dst));
+            assertEquals(dst[0], (byte) 77);
+        } finally {
+            art.close();
+        }
+    }
+
+    @Test
+    public void testRemoveAgainstOracle() {
+        int keyLen = 6, vsize = 8;
+        Random r = new Random(2024);
+        TreeMap<byte[], byte[]> oracle = new TreeMap<>(CMP);
+        OffHeapART art = new OffHeapART(keyLen, vsize);
+        byte[] dst = new byte[vsize];
+        try {
+            for (int i = 0; i < 40_000; i++) {
+                byte[] k = randomKey(r, keyLen);
+                byte[] v = randomValue(r, vsize);
+                art.put(k, v);
+                oracle.put(k, v);
+            }
+            // remove ~half
+            List<byte[]> snapshot = new ArrayList<>(oracle.keySet());
+            for (int i = 0; i < snapshot.size(); i += 2) {
+                byte[] k = snapshot.get(i);
+                assertTrue(art.remove(k));
+                oracle.remove(k);
+            }
+            assertFalse(art.remove(snapshot.get(0))); // already gone
+            assertEquals(art.size(), (long) oracle.size());
+            for (Map.Entry<byte[], byte[]> e : oracle.entrySet()) {
+                assertTrue(art.get(e.getKey(), dst), "missing after removes");
+                assertEquals(dst, e.getValue());
+            }
+            // removed keys absent; ordering still correct
+            for (int i = 0; i < snapshot.size(); i += 2) assertFalse(art.contains(snapshot.get(i)));
+            assertSameOrder(new ArrayList<>(oracle.keySet()), toList(art.scan(null, null)));
+        } finally {
+            art.close();
+        }
+    }
+
+    private static boolean startsWith(byte[] key, byte[] prefix) {
+        if (key.length < prefix.length) return false;
+        for (int i = 0; i < prefix.length; i++) if (key[i] != prefix[i]) return false;
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Adds **opt-in prefix/range scanning** to HaloDB. With `HaloDBOptions.setUseOrderedIndex(true)` (and a fixed key size), HaloDB maintains an off-heap **adaptive radix tree** of the key set alongside the existing hash index, and `HaloDB.prefixScan(byte[] prefix)` returns records in ascending key order.

The hash index is **unchanged**, so point reads and all existing behavior are unaffected — the ordered index is a side index used only for scans.

## Why this design (augment, not replace)

We explored replacing the hash with a single ordered index. Two findings ruled that out:
- **End-to-end, the index is ~invisible.** A real `get` is dominated by the record `pread`; measured hash-vs-ART end-to-end `get` latency was within <1% (cache-hot small records) and the index is ~2–3% of a large-record get. So replacing the hash buys nothing on the hot path.
- **Concurrency.** HaloDB's index is multi-writer (the compaction thread also mutates it, lock-free) + lock-free-reader. A single ART would need a concurrent multi-writer ART on the core read path — high risk for zero end-to-end gain.

Augment keeps the proven concurrent hash for the hot path and makes the ART **single-writer**: only `put`/`delete` (and the open-build) change key membership; compaction's `replace` doesn't, so it never touches the ART.

## What's here

- **`OffHeapART`** — off-heap adaptive radix tree for fixed-length keys (pointer-tagged child pointers, lazy leaves, SWAR Node16 search, Node48 folded into Node256). `put` / `get` / `remove` / ordered `scan` / `prefixScan`. Lives entirely off-heap via the FFM `Uns` layer.
- **`InMemoryIndex`** maintains the ART on `put`/`putIfAbsent`/`remove`, serialized by a `ReadWriteLock` (correct under the parallel open-build). `prefixScanKeys` snapshots matching keys under the read lock; records are then read lock-free, so the lock is never held during disk I/O.
- **`HaloDB.prefixScan(byte[])`** → `Iterator<Record>`; **`HaloDBOptions.setUseOrderedIndex`**.

## Limitations
- Requires **fixed-length keys** (all keys exactly `fixedKeySize`).
- A scan materializes its matching key set; very large prefix scans hold that set in memory. Fully-streaming-under-concurrent-writes (epoch reclamation) is a future optimization.
- ART `remove` unlinks without merging under-full nodes (correct, slightly less compact).

## Testing
- `OffHeapARTTest`: ART vs `TreeMap` oracle — node growth through all types, removes, prefix/range scans, overwrite.
- `HaloDBPrefixScanTest`: end-to-end — oracle match across prefixes, reflects deletes, survives close/reopen (rebuilt during open), errors when disabled.
- Full suite green: **301 tests, 0 failures** on JDK 25.