### PR TITLE
Update dependencies (consolidated, verified)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,15 +76,15 @@ ThisBuild / resolvers += Resolver.mavenLocal
 ThisBuild / outputStrategy := Some(StdoutOutput)
 
 libraryDependencies ++= Seq(
-  "org.slf4j" % "slf4j-api" % "1.7.12",
-  "com.google.guava" % "guava" % "18.0",
+  "org.slf4j" % "slf4j-api" % "1.7.36",
+  "com.google.guava" % "guava" % "33.6.0-jre",
   "net.jpountz.lz4" % "lz4" % "1.3",
   "org.hamcrest" % "hamcrest-all" % "1.3" % Test,
-  "org.apache.logging.log4j" % "log4j-core" % "2.3" % Test,
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.3" % Test,
+  "org.apache.logging.log4j" % "log4j-core" % "2.26.0" % Test,
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.26.0" % Test,
   "org.testng" % "testng" % "6.9.10" % Test,
   "org.jmockit" % "jmockit" % "1.49" % Test,
-  "org.assertj" % "assertj-core" % "3.8.0" % Test
+  "org.assertj" % "assertj-core" % "3.27.7" % Test
 )
 
 // Benchmark subproject: side-by-side comparison against RocksDB. Depends on HaloDB source

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.5
+sbt.version=1.10.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 

--- a/src/main/java/com/oath/halodb/OffHeapHashTableStats.java
+++ b/src/main/java/com/oath/halodb/OffHeapHashTableStats.java
@@ -7,7 +7,7 @@
 
 package com.oath.halodb;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 final class OffHeapHashTableStats {
 
@@ -73,7 +73,7 @@ final class OffHeapHashTableStats {
     }
 
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
             .add("hitCount", hitCount)
             .add("missCount", missCount)
             .add("size", size)


### PR DESCRIPTION
## Summary

Consolidates the **safe subset** of the Scala Steward dependency PRs (#4–#11), since they conflict pairwise on `build.sbt`, one needs an accompanying code change, and two break the suite. Verified against the full test suite: **282 tests, 0 failures**.

## Applied
- **guava 18.0 → 33.6.0-jre** — guava removed `Objects.toStringHelper` long ago; replaced the one remaining use in `OffHeapHashTableStats` with `MoreObjects.toStringHelper`. (So Steward's #5 could not merge on its own — it would break compilation.)
- slf4j-api 1.7.12 → 1.7.36
- log4j 2.3 → 2.26.0 (test)
- assertj-core 3.8.0 → 3.27.7 (test)
- sbt 1.10.5 → 1.10.11; sbt-pgp 2.3.0 → 2.3.1

## Held back (and why)
- **testng → kept 6.9.10.** 6.9.13.6 changes skip behavior and *un-skips* a fragile pre-existing fault-injection test (`CompactionWithErrorsTest.testCompactionThreadStopWithIOException`), which then fails. Confirmed by isolating it: skipped/green on master, fails when un-skipped. Not worth a patch bump that turns CI red.
- **jmockit → kept 1.49.** 1.49 was chosen deliberately for JDK 25; no evidence 1.50 is needed, and the project has a history of jmockit/JDK incompatibilities.

Supersedes Scala Steward PRs #4, #5, #6, #7, #9, #10 (folded in here); #8 (jmockit) and #11 (testng) intentionally not adopted.