### PR TITLE
Fix flaky tests by activating jmockit's per-test scoping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,10 @@ testNG := {
   IO.write(suite,
     """<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
       |<suite name="HaloDB" verbose="1">
+      |  <!-- Activate jmockit's per-test scoping so MockUps are torn down after each test. Without
+      |       it, a fault-injection mock (e.g. CompactionWithErrorsTest) leaks into a later test's
+      |       compaction thread and fails it intermittently. -->
+      |  <listeners><listener class-name="mockit.integration.testng.TestNGRunnerDecorator"/></listeners>
       |  <test name="all"><packages><package name="com.oath.halodb"/></packages></test>
       |</suite>""".stripMargin)
   val options = ForkOptions().withRunJVMOptions(Vector(


### PR DESCRIPTION
## Problem

CI occasionally went red on unrelated PRs with a failure in a compaction test (e.g. `HaloDBCompactionTest.testSyncWrites` — "Error while closing"), even though the change under test was innocent (it flaked on one JDK and passed on re-run).

## Root cause

The custom forked TestNG runner (the `testNG` task) was **not activating jmockit's TestNG integration**, so jmockit's `MockUp`s were never torn down per test. A fault-injection mock in `CompactionWithErrorsTest` — `CompactionManager.stopCompactionThread` throwing `IOException` (and a `RateLimiter` OOM) — **leaked into a later test's compaction thread** and failed it.

Reproduced deterministically by running `CompactionWithErrorsTest` immediately before `HaloDBCompactionTest`: `testSyncWrites` fails because its `db.close()` hits the leaked, still-installed mock. (The same missing integration is why the `@Mocked`-parameter test was being silently skipped.)

## Fix

Register `mockit.integration.testng.TestNGRunnerDecorator` as a listener in the generated TestNG suite, restoring jmockit's per-test scoping so mocks are discarded after each test.

## Verification

- The reproducer (`CompactionWithErrorsTest` + `HaloDBCompactionTest`) went from **14 pass / 1 fail** to **15 pass / 0 fail**, stable over repeated runs.
- Full suite: **282 tests, 0 failures, 1 skip** — no regression, and no previously-skipped test is un-skipped (so no new fragile test is introduced).