### PR TITLE
Support arbitrary-length keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ is allocated in native memory, outside the Java heap.
             // A segment's memory is further divided into chunks whose size can be configured here. 
             options.setMemoryPoolChunkSize(2 * 1024 * 1024);
     
-            // using a memory pool requires us to declare the size of keys in advance.
-            // Any write request with key length greater than the declared value will fail, but it
-            // is still possible to store keys smaller than this declared size. 
+            // With a memory pool, fixedKeySize declares the inline key size of each slot. Keys up to
+            // this size occupy a single slot; longer keys overflow into additional chained slots, so
+            // keys of any length are supported (set this to your typical key size for best density).
             options.setFixedKeySize(8);
     
             // Represents a database instance and provides all methods for operating on the database.
@@ -106,7 +106,7 @@ is allocated in native memory, outside the Java heap.
             // index files to create the in-memory index, which, depending on the db size, might take a few minutes.
             db = HaloDB.open(directory, options);
     
-            // key and values are byte arrays. Key size is restricted to 128 bytes.
+            // keys and values are byte arrays; keys may be of any length.
             byte[] key1 = Ints.toByteArray(200);
             byte[] value1 = "Value for key 1".getBytes();
     
@@ -227,9 +227,11 @@ index threads to number of available processors divided by number of dbs being o
 Therefore, don't interrupt threads while they are doing IO operations.
 
 ### Restrictions. 
-* Size of keys is restricted to 128 bytes.  
+* Keys may be of any length. (The optional ordered index still requires fixed-length keys.)
 * By default HaloDB does not support range scans or ordered access. An optional ordered index enables
   prefix/range scans — see below.
+* **On-disk format:** key length is stored as a 4-byte int (format version 1). Databases written by
+  versions before 0.7 (format version 0) are not readable and must be rebuilt.
 
 ### Prefix and range scanning (optional).
 By default the in-memory index is a hash table, so reads are point lookups only. Enabling the ordered

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,10 +21,15 @@ Override any preset value, or pick engines:
 
 ```bash
 sbt "benchmarks/run quick --records=5000000 --record-size=512 --reads=10000000 --read-threads=16"
+sbt "benchmarks/run quick --key-size=1024"           # large keys (default 8 B; min 8 B)
 sbt "benchmarks/run quick --engines=halodb"          # one engine only
 sbt "benchmarks/run quick --rocks-compress=true"      # enable RocksDB LZ4 compression
 sbt "benchmarks/run quick --dir=/mnt/ssd/bench"        # data directory (default: target/benchmark-data)
 ```
+
+`--key-size` sweeps key length to measure the point-read/write path on large keys. Prefix scan is
+skipped when `key-size` exceeds 127 (HaloDB's ordered index requires fixed keys ≤ 127 B); large keys
+still work for point reads/writes via the hash index.
 
 Sample results (one workstation, in page cache — directional only). See
 [`docs/benchmarks.md`](../docs/benchmarks.md) for the full write-up.

--- a/benchmarks/src/main/java/com/oath/halodb/benchmarks/Comparison.java
+++ b/benchmarks/src/main/java/com/oath/halodb/benchmarks/Comparison.java
@@ -42,11 +42,17 @@ public class Comparison {
     static final class Config {
         long records;
         int recordSize;
+        int keySize = 8;
         long reads;
         int readThreads;
         boolean rocksCompress;
         File dir;
         List<String> engines = new ArrayList<>(List.of("halodb", "rocksdb"));
+    }
+
+    // Prefix scan needs HaloDB's ordered (ART) index, which requires fixed keys <= 127 bytes.
+    static boolean prefixScanSupported(Config cfg) {
+        return cfg.keySize <= 127;
     }
 
     static final class Result {
@@ -69,10 +75,11 @@ public class Comparison {
 
         double dataGb = cfg.records * (double) cfg.recordSize / (1024 * 1024 * 1024);
         System.out.printf(
-            "Workload: records=%,d  recordSize=%dB  reads=%,d  readThreads=%d  (~%.2f GB of values)%n",
-            cfg.records, cfg.recordSize, cfg.reads, cfg.readThreads, dataGb);
-        System.out.printf("Engines: %s   dir=%s   rocksCompress=%s%n%n",
-            cfg.engines, cfg.dir, cfg.rocksCompress);
+            "Workload: records=%,d  recordSize=%dB  keySize=%dB  reads=%,d  readThreads=%d  (~%.2f GB of values)%n",
+            cfg.records, cfg.recordSize, cfg.keySize, cfg.reads, cfg.readThreads, dataGb);
+        System.out.printf("Engines: %s   dir=%s   rocksCompress=%s%s%n%n",
+            cfg.engines, cfg.dir, cfg.rocksCompress,
+            prefixScanSupported(cfg) ? "" : "   (prefix scan skipped: keySize > 127)");
 
         Map<String, Result> results = new LinkedHashMap<>();
         for (String engine : cfg.engines) {
@@ -81,7 +88,7 @@ public class Comparison {
             dir.mkdirs();
             StorageEngine db = engine.equals("rocksdb")
                 ? new RocksDBStorageEngine(dir, cfg.rocksCompress)
-                : new HaloDBStorageEngine(dir, cfg.records);
+                : new HaloDBStorageEngine(dir, cfg.records, cfg.keySize);
             System.out.printf("==== %s ====%n", engine);
             db.open();
             try {
@@ -100,9 +107,11 @@ public class Comparison {
         r.engine = engine;
 
         // ---- FILL: sequential keys, reused value buffer (unique in first 8 bytes) ----
+        // Keys are cfg.keySize bytes; the id is written into the first 8 bytes (the rest are zero),
+        // so keys are deterministic and unique, and a key of any size can be regenerated from its id.
         byte[] value = new byte[cfg.recordSize];
         new Random(SEED).nextBytes(value);
-        byte[] key = new byte[8];
+        byte[] key = new byte[cfg.keySize];
         long fillStart = System.nanoTime();
         for (long i = 0; i < cfg.records; i++) {
             writeLong(key, i);
@@ -119,7 +128,7 @@ public class Comparison {
         // ---- WARMUP reads (untimed): warms page cache, JIT, and lets writes settle ----
         long warmup = Math.min(cfg.records, Math.max(1, cfg.reads / 10));
         Random wr = new Random(SEED);
-        byte[] wk = new byte[8];
+        byte[] wk = new byte[cfg.keySize];
         for (long i = 0; i < warmup; i++) {
             writeLong(wk, Math.floorMod(wr.nextLong(), cfg.records));
             db.get(wk);
@@ -130,7 +139,7 @@ public class Comparison {
         ReadWorker[] workers = new ReadWorker[cfg.readThreads];
         long readStart = System.nanoTime();
         for (int t = 0; t < cfg.readThreads; t++) {
-            workers[t] = new ReadWorker(db, perThread, cfg.records, SEED + t);
+            workers[t] = new ReadWorker(db, perThread, cfg.records, cfg.keySize, SEED + t);
             workers[t].start();
         }
         long misses = 0;
@@ -148,9 +157,14 @@ public class Comparison {
             r.readOpsPerSec, r.readSeconds, misses);
 
         // ---- PREFIX SCAN: scan keys sharing the first 7 bytes (~256-key blocks), random blocks ----
+        // Only when the ordered index is available (keySize <= 127); skipped for large keys.
+        if (!prefixScanSupported(cfg)) {
+            System.out.println("  prefixScan: skipped (keySize > 127, ordered index unavailable)");
+            return r;
+        }
         int scans = (int) Math.min(2000, Math.max(1, cfg.records / 256));
         Random pr = new Random(SEED + 999);
-        byte[] full = new byte[8];
+        byte[] full = new byte[cfg.keySize];
         long matched = 0;
         long pStart = System.nanoTime();
         for (int i = 0; i < scans; i++) {
@@ -172,21 +186,23 @@ public class Comparison {
         final StorageEngine db;
         final long count;
         final long records;
+        final int keySize;
         final long seed;
         final Histogram histogram = new Histogram(TimeUnit.SECONDS.toNanos(10), 3);
         long misses = 0;
 
-        ReadWorker(StorageEngine db, long count, long records, long seed) {
+        ReadWorker(StorageEngine db, long count, long records, int keySize, long seed) {
             this.db = db;
             this.count = count;
             this.records = records;
+            this.keySize = keySize;
             this.seed = seed;
         }
 
         @Override
         public void run() {
             Random rand = new Random(seed);
-            byte[] key = new byte[8];
+            byte[] key = new byte[keySize];
             for (long i = 0; i < count; i++) {
                 writeLong(key, Math.floorMod(rand.nextLong(), records));
                 long s = System.nanoTime();
@@ -281,6 +297,7 @@ public class Comparison {
             switch (k) {
                 case "records": cfg.records = Long.parseLong(v); break;
                 case "record-size": cfg.recordSize = Integer.parseInt(v); break;
+                case "key-size": cfg.keySize = Integer.parseInt(v); break;
                 case "reads": cfg.reads = Long.parseLong(v); break;
                 case "read-threads": cfg.readThreads = Integer.parseInt(v); break;
                 case "dir": cfg.dir = new File(v); break;
@@ -292,6 +309,7 @@ public class Comparison {
             }
         }
         if (cfg.recordSize < 8) throw new IllegalArgumentException("record-size must be >= 8");
+        if (cfg.keySize < 8) throw new IllegalArgumentException("key-size must be >= 8");
         return cfg;
     }
 

--- a/benchmarks/src/main/java/com/oath/halodb/benchmarks/HaloDBStorageEngine.java
+++ b/benchmarks/src/main/java/com/oath/halodb/benchmarks/HaloDBStorageEngine.java
@@ -19,10 +19,16 @@ public class HaloDBStorageEngine implements StorageEngine {
 
     private HaloDB db;
     private final long noOfRecords;
+    private final int keySize;
 
     public HaloDBStorageEngine(File dbDirectory, long noOfRecords) {
+        this(dbDirectory, noOfRecords, 8);
+    }
+
+    public HaloDBStorageEngine(File dbDirectory, long noOfRecords, int keySize) {
         this.dbDirectory = dbDirectory;
         this.noOfRecords = noOfRecords;
+        this.keySize = keySize;
     }
 
     @Override
@@ -80,8 +86,13 @@ public class HaloDBStorageEngine implements StorageEngine {
         opts.setNumberOfRecords(Ints.checkedCast(2 * noOfRecords));
         opts.setCompactionJobRate(135 * 1024 * 1024);
         opts.setUseMemoryPool(true);
-        opts.setFixedKeySize(8);
-        opts.setUseOrderedIndex(true); // enable prefix/range scans
+        opts.setFixedKeySize(keySize);
+        // The ordered (ART) index requires fixed keys <= 127 bytes; enable prefix/range scans only
+        // when the configured key size fits. Larger keys still work for point reads/writes via the
+        // hash index (overflowing into chained memory-pool slots).
+        if (keySize <= 127) {
+            opts.setUseOrderedIndex(true); // enable prefix/range scans
+        }
 
         try {
             db = HaloDB.open(dbDirectory, opts);

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -85,6 +85,33 @@ workload HaloDB targets. The ordered index does not change point-read latency (t
 untouched); its cost is per-write maintenance and roughly 2× index memory, and it requires
 fixed-length keys.
 
+## Key-size scaling
+
+HaloDB supports **keys of any length** (the 127-byte cap was removed). With the memory pool, keys
+longer than `fixedKeySize` overflow into chained slots; with the non-pool index they're stored
+inline. To show how key size affects the point-read/write path, the workload below holds the value
+size constant (256 B, 500,000 records) and sweeps the key from 8 B to 4 KB. (Prefix scan is omitted
+here — the ordered index still requires fixed keys ≤ 127 B.)
+
+| key size | WRITE · HaloDB | WRITE · RocksDB | READ · HaloDB | READ · RocksDB | READ p50 · HaloDB | READ p50 · RocksDB |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 8 B   | 400,193 | 1,762,290 | 2,735,662 | 2,078,608 | 1.8 µs | 3.5 µs |
+| 64 B  | 365,036 | 1,703,833 | 2,756,031 | 2,191,073 | 2.0 µs | 3.2 µs |
+| 256 B | 323,389 | 1,415,057 | 2,167,669 | 1,524,574 | 2.3 µs | 4.3 µs |
+| 1 KB  | 196,893 | 1,071,512 | 2,053,670 | 2,028,665 | 2.6 µs | 3.4 µs |
+| 4 KB  |  77,090 |   689,119 | 1,874,241 | 1,581,044 | 3.7 µs | 4.4 µs |
+
+![Random read throughput by key size (ops/sec) — higher is better](images/read-by-keysize.svg)
+
+![Write throughput by key size (ops/sec) — higher is better](images/write-by-keysize.svg)
+
+**Reads stay HaloDB's strength at every key size** — higher throughput and lower p50 latency than
+RocksDB from 8 B all the way to 4 KB, because a read is still one seek regardless of key length.
+**Writes cost more as keys grow:** HaloDB must append the full key to its log and (with the memory
+pool) thread it across chained index slots, so write throughput falls off faster than RocksDB's as
+keys get large. Large keys therefore fit HaloDB's read-heavy sweet spot well; very large keys on a
+write-heavy workload are where RocksDB's gap widens. As always, benchmark your own key/value mix.
+
 ## Why HaloDB makes these trade-offs
 
 HaloDB was written for read-latency-critical, IO-bound workloads of large records. It optimizes for

--- a/docs/images/generate_charts.py
+++ b/docs/images/generate_charts.py
@@ -149,6 +149,17 @@ CHARTS = {
         ["1KB", "16KB", "256KB", "1MB", "10MB"],
         {"HaloDB": [1051824, 265794, 32905, 9639, 847],
          "RocksDB": [1236131, 209773, 21629, 5068, 421]}, "", log=True),
+    # Key-size scaling (256-byte values, 500k records). Point reads/writes only.
+    "read-by-keysize.svg": chart(
+        "Random read throughput by key size (ops/sec) — higher is better",
+        ["8 B", "64 B", "256 B", "1 KB", "4 KB"],
+        {"HaloDB": [2735662, 2756031, 2167669, 2053670, 1874241],
+         "RocksDB": [2078608, 2191073, 1524574, 2028665, 1581044]}, ""),
+    "write-by-keysize.svg": chart(
+        "Write throughput by key size (ops/sec) — higher is better",
+        ["8 B", "64 B", "256 B", "1 KB", "4 KB"],
+        {"HaloDB": [400193, 365036, 323389, 196893, 77090],
+         "RocksDB": [1762290, 1703833, 1415057, 1071512, 689119]}, ""),
 }
 
 if __name__ == "__main__":

--- a/docs/images/read-by-keysize.svg
+++ b/docs/images/read-by-keysize.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="612" viewBox="0 0 940 612" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif">
+<rect width="940" height="612" fill="#ffffff"/>
+<text x="24" y="40" font-size="22" font-weight="600" fill="#202124">Random read throughput by key size (ops/sec) — higher is better</text>
+<rect x="732" y="56" width="14" height="14" rx="2" fill="#4285F4"/>
+<text x="752" y="68" font-size="14" fill="#5f6368">HaloDB</text>
+<rect x="828" y="56" width="14" height="14" rx="2" fill="#E8B33A"/>
+<text x="848" y="68" font-size="14" fill="#5f6368">RocksDB</text>
+<line x1="70.0" y1="96" x2="70.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="70.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">0</text>
+<line x1="238.0" y1="96" x2="238.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="238.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">600,000</text>
+<line x1="406.0" y1="96" x2="406.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="406.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">1,200,000</text>
+<line x1="574.0" y1="96" x2="574.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="574.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">1,800,000</text>
+<line x1="742.0" y1="96" x2="742.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="742.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">2,400,000</text>
+<line x1="910.0" y1="96" x2="910.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="910.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">3,000,000</text>
+<line x1="70" y1="96" x2="70" y2="556" stroke="#bdc1c6" stroke-width="1.5"/>
+<rect x="70" y="96" width="766.0" height="30" fill="#4285F4"/>
+<text x="826.0" y="116.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">2,735,662</text>
+<rect x="70" y="134" width="582.0" height="30" fill="#E8B33A"/>
+<text x="642.0" y="154.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">2,078,608</text>
+<text x="58" y="135.0" font-size="14" fill="#5f6368" text-anchor="end">8 B</text>
+<rect x="70" y="194" width="771.7" height="30" fill="#4285F4"/>
+<text x="831.7" y="214.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">2,756,031</text>
+<rect x="70" y="232" width="613.5" height="30" fill="#E8B33A"/>
+<text x="673.5" y="252.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">2,191,073</text>
+<text x="58" y="233.0" font-size="14" fill="#5f6368" text-anchor="end">64 B</text>
+<rect x="70" y="292" width="606.9" height="30" fill="#4285F4"/>
+<text x="666.9" y="312.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">2,167,669</text>
+<rect x="70" y="330" width="426.9" height="30" fill="#E8B33A"/>
+<text x="486.9" y="350.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">1,524,574</text>
+<text x="58" y="331.0" font-size="14" fill="#5f6368" text-anchor="end">256 B</text>
+<rect x="70" y="390" width="575.0" height="30" fill="#4285F4"/>
+<text x="635.0" y="410.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">2,053,670</text>
+<rect x="70" y="428" width="568.0" height="30" fill="#E8B33A"/>
+<text x="628.0" y="448.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">2,028,665</text>
+<text x="58" y="429.0" font-size="14" fill="#5f6368" text-anchor="end">1 KB</text>
+<rect x="70" y="488" width="524.8" height="30" fill="#4285F4"/>
+<text x="584.8" y="508.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">1,874,241</text>
+<rect x="70" y="526" width="442.7" height="30" fill="#E8B33A"/>
+<text x="502.7" y="546.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">1,581,044</text>
+<text x="58" y="527.0" font-size="14" fill="#5f6368" text-anchor="end">4 KB</text>
+</svg>

--- a/docs/images/write-by-keysize.svg
+++ b/docs/images/write-by-keysize.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="612" viewBox="0 0 940 612" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif">
+<rect width="940" height="612" fill="#ffffff"/>
+<text x="24" y="40" font-size="22" font-weight="600" fill="#202124">Write throughput by key size (ops/sec) — higher is better</text>
+<rect x="732" y="56" width="14" height="14" rx="2" fill="#4285F4"/>
+<text x="752" y="68" font-size="14" fill="#5f6368">HaloDB</text>
+<rect x="828" y="56" width="14" height="14" rx="2" fill="#E8B33A"/>
+<text x="848" y="68" font-size="14" fill="#5f6368">RocksDB</text>
+<line x1="70.0" y1="96" x2="70.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="70.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">0</text>
+<line x1="238.0" y1="96" x2="238.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="238.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">400,000</text>
+<line x1="406.0" y1="96" x2="406.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="406.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">800,000</text>
+<line x1="574.0" y1="96" x2="574.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="574.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">1,200,000</text>
+<line x1="742.0" y1="96" x2="742.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="742.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">1,600,000</text>
+<line x1="910.0" y1="96" x2="910.0" y2="556" stroke="#e3e6ea" stroke-width="1"/>
+<text x="910.0" y="578" font-size="12" fill="#5f6368" text-anchor="middle">2,000,000</text>
+<line x1="70" y1="96" x2="70" y2="556" stroke="#bdc1c6" stroke-width="1.5"/>
+<rect x="70" y="96" width="168.1" height="30" fill="#4285F4"/>
+<text x="228.1" y="116.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">400,193</text>
+<rect x="70" y="134" width="740.2" height="30" fill="#E8B33A"/>
+<text x="800.2" y="154.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">1,762,290</text>
+<text x="58" y="135.0" font-size="14" fill="#5f6368" text-anchor="end">8 B</text>
+<rect x="70" y="194" width="153.3" height="30" fill="#4285F4"/>
+<text x="213.3" y="214.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">365,036</text>
+<rect x="70" y="232" width="715.6" height="30" fill="#E8B33A"/>
+<text x="775.6" y="252.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">1,703,833</text>
+<text x="58" y="233.0" font-size="14" fill="#5f6368" text-anchor="end">64 B</text>
+<rect x="70" y="292" width="135.8" height="30" fill="#4285F4"/>
+<text x="195.8" y="312.0" font-size="14" font-weight="600" fill="#ffffff" text-anchor="end">323,389</text>
+<rect x="70" y="330" width="594.3" height="30" fill="#E8B33A"/>
+<text x="654.3" y="350.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">1,415,057</text>
+<text x="58" y="331.0" font-size="14" fill="#5f6368" text-anchor="end">256 B</text>
+<rect x="70" y="390" width="82.7" height="30" fill="#4285F4"/>
+<text x="160.7" y="410.0" font-size="14" font-weight="600" fill="#202124" text-anchor="start">196,893</text>
+<rect x="70" y="428" width="450.0" height="30" fill="#E8B33A"/>
+<text x="510.0" y="448.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">1,071,512</text>
+<text x="58" y="429.0" font-size="14" fill="#5f6368" text-anchor="end">1 KB</text>
+<rect x="70" y="488" width="32.4" height="30" fill="#4285F4"/>
+<text x="110.4" y="508.0" font-size="14" font-weight="600" fill="#202124" text-anchor="start">77,090</text>
+<rect x="70" y="526" width="289.4" height="30" fill="#E8B33A"/>
+<text x="349.4" y="546.0" font-size="14" font-weight="600" fill="#202124" text-anchor="end">689,119</text>
+<text x="58" y="527.0" font-size="14" fill="#5f6368" text-anchor="end">4 KB</text>
+</svg>

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -920,8 +920,11 @@ class HaloDBInternal {
     }
 
     private static void checkIfOptionsAreCorrect(HaloDBOptions options) {
-        if (options.isUseMemoryPool() && (options.getFixedKeySize() < 0 || options.getFixedKeySize() > Byte.MAX_VALUE)) {
-            throw new IllegalArgumentException("fixedKeySize must be set and should be less than 128 when using memory pool");
+        if (options.isUseMemoryPool() && options.getFixedKeySize() <= 0) {
+            // fixedKeySize is the inline portion of a memory-pool slot; keys longer than it overflow
+            // into chained slots, so there is no upper bound here (a slot must still fit in a chunk,
+            // which MemoryPoolChunk validates). It must, however, be a positive value.
+            throw new IllegalArgumentException("fixedKeySize must be a positive value when using memory pool");
         }
         if (options.isUseOrderedIndex() && (options.getFixedKeySize() <= 0 || options.getFixedKeySize() > Byte.MAX_VALUE)) {
             throw new IllegalArgumentException("ordered index requires a fixedKeySize in (0, 127]; all keys must be exactly that length");

--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -218,9 +218,6 @@ class HaloDBInternal {
     }
 
     boolean put(byte[] key, byte[] value) throws IOException, HaloDBException {
-        if (key.length > Byte.MAX_VALUE) {
-            throw new HaloDBException("key length cannot exceed " + Byte.MAX_VALUE);
-        }
         if (options.isUseOrderedIndex() && key.length != options.getFixedKeySize()) {
             throw new HaloDBException("ordered index requires keys of exactly fixedKeySize (" + options.getFixedKeySize() + ") bytes");
         }

--- a/src/main/java/com/oath/halodb/IndexFileEntry.java
+++ b/src/main/java/com/oath/halodb/IndexFileEntry.java
@@ -14,28 +14,28 @@ import java.util.zip.CRC32;
 class IndexFileEntry {
 
     /**
-     * checksum         - 4 bytes. 
+     * checksum         - 4 bytes.
      * version          - 1 byte.
-     * Key size         - 1 bytes.
+     * Key size         - 4 bytes.
      * record size      - 4 bytes.
      * record offset    - 4 bytes.
      * sequence number  - 8 bytes
      */
-    final static int INDEX_FILE_HEADER_SIZE = 22;
+    final static int INDEX_FILE_HEADER_SIZE = 25;
     final static int CHECKSUM_SIZE = 4;
 
     static final int CHECKSUM_OFFSET = 0;
     static final int VERSION_OFFSET = 4;
     static final int KEY_SIZE_OFFSET = 5;
-    static final int RECORD_SIZE_OFFSET = 6;
-    static final int RECORD_OFFSET = 10;
-    static final int SEQUENCE_NUMBER_OFFSET = 14;
+    static final int RECORD_SIZE_OFFSET = 9;
+    static final int RECORD_OFFSET = 13;
+    static final int SEQUENCE_NUMBER_OFFSET = 17;
 
 
     private final byte[] key;
     private final int recordSize;
     private final int recordOffset;
-    private final byte keySize;
+    private final int keySize;
     private final int version;
     private final long sequenceNumber;
     private final long checkSum;
@@ -48,7 +48,7 @@ class IndexFileEntry {
         this.version = version;
         this.checkSum = checkSum;
 
-        this.keySize = (byte)key.length;
+        this.keySize = key.length;
     }
 
     ByteBuffer[] serialize() {
@@ -56,7 +56,7 @@ class IndexFileEntry {
         ByteBuffer h = ByteBuffer.wrap(header);
 
         h.put(VERSION_OFFSET, (byte)version);
-        h.put(KEY_SIZE_OFFSET, keySize);
+        h.putInt(KEY_SIZE_OFFSET, keySize);
         h.putInt(RECORD_SIZE_OFFSET, recordSize);
         h.putInt(RECORD_OFFSET, recordOffset);
         h.putLong(SEQUENCE_NUMBER_OFFSET, sequenceNumber);
@@ -69,7 +69,7 @@ class IndexFileEntry {
     static IndexFileEntry deserialize(ByteBuffer buffer) {
         long crc32 = Utils.toUnsignedIntFromInt(buffer.getInt());
         int version = Utils.toUnsignedByte(buffer.get());
-        byte keySize = buffer.get();
+        int keySize = buffer.getInt();
         int recordSize = buffer.getInt();
         int offset = buffer.getInt();
         long sequenceNumber = buffer.getLong();
@@ -87,7 +87,7 @@ class IndexFileEntry {
 
         long crc32 = Utils.toUnsignedIntFromInt(buffer.getInt());
         int version = Utils.toUnsignedByte(buffer.get());
-        byte keySize = buffer.get();
+        int keySize = buffer.getInt();
         int recordSize = buffer.getInt();
         int offset = buffer.getInt();
         long sequenceNumber = buffer.getLong();
@@ -119,7 +119,7 @@ class IndexFileEntry {
     long computeCheckSum() {
         ByteBuffer header = ByteBuffer.allocate(INDEX_FILE_HEADER_SIZE);
         header.put(VERSION_OFFSET, (byte)version);
-        header.put(KEY_SIZE_OFFSET, keySize);
+        header.putInt(KEY_SIZE_OFFSET, keySize);
         header.putInt(RECORD_SIZE_OFFSET, recordSize);
         header.putInt(RECORD_OFFSET, recordOffset);
         header.putLong(SEQUENCE_NUMBER_OFFSET, sequenceNumber);

--- a/src/main/java/com/oath/halodb/MemoryPoolChunk.java
+++ b/src/main/java/com/oath/halodb/MemoryPoolChunk.java
@@ -10,7 +10,16 @@ import java.nio.ByteBuffer;
 import static com.oath.halodb.MemoryPoolHashEntries.*;
 
 /**
- * Memory pool is divided into chunks of configurable size. This represents such a chunk.
+ * Memory pool is divided into chunks of configurable size, each holding a number of fixed-size
+ * slots. This represents such a chunk.
+ *
+ * <p>A slot is either the HEAD of an entry — holding the next pointer, the (int) key length, up to
+ * {@code fixedKeyLength} inline key bytes and the {@code fixedValueLength} value — or an OVERFLOW
+ * slot holding a key fragment for a key longer than {@code fixedKeyLength}. Slots are addressed by
+ * their byte offset within the chunk and chained, across chunks if necessary, via the next pointer.
+ * See {@link MemoryPoolHashEntries} for the byte layout. This class only reads and writes slot
+ * fields; the chaining of head and overflow slots into entries is managed by
+ * {@link SegmentWithMemoryPool}.
  */
 class MemoryPoolChunk {
 
@@ -42,58 +51,23 @@ class MemoryPoolChunk {
         Uns.free(address);
     }
 
-    MemoryPoolAddress getNextAddress(int slotOffset) {
-        byte chunkIndex = Uns.getByte(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_INDEX);
-        int chunkOffset = Uns.getInt(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_OFFSET);
-
-        return new MemoryPoolAddress(chunkIndex, chunkOffset);
+    /** Number of bytes a key fragment can hold in a single overflow slot. */
+    int fragmentCapacity() {
+        return fixedSlotSize - ENTRY_OFF_FRAGMENT;
     }
 
-    void setNextAddress(int slotOffset, MemoryPoolAddress next) {
-        Uns.putByte(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_INDEX, next.chunkIndex);
-        Uns.putInt(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_OFFSET, next.chunkOffset);
-    }
+    // ---- slot allocation (sequential fill of fresh slots) ----
 
-    /**
-     * Relative put method. Writes to the slot pointed to by the writeOffset and increments the writeOffset.
-     */
-    void fillNextSlot(byte[] key, byte[] value, MemoryPoolAddress nextAddress) {
-        fillSlot(writeOffset, key, value, nextAddress);
+    /** Reserve the next free slot in this chunk, returning its offset. */
+    int allocateSlot() {
+        if (chunkSize - writeOffset < fixedSlotSize) {
+            throw new IllegalArgumentException(
+                String.format("Chunk full. Chunk size %d. write offset %d. fixed slot size %d",
+                              chunkSize, writeOffset, fixedSlotSize));
+        }
+        int slotOffset = writeOffset;
         writeOffset += fixedSlotSize;
-    }
-
-    /**
-     * Absolute put method. Writes to the slot pointed to by the offset.
-     */
-    void fillSlot(int slotOffset, byte[] key, byte[] value, MemoryPoolAddress nextAddress) {
-        if (key.length > fixedKeyLength || value.length != fixedValueLength) {
-            throw new IllegalArgumentException(
-                String.format("Invalid request. Key length %d. fixed key length %d. Value length %d",
-                              key.length, fixedKeyLength, value.length)
-            );
-        }
-        if (chunkSize - slotOffset < fixedSlotSize) {
-            throw new IllegalArgumentException(
-                String.format("Invalid offset %d. Chunk size %d. fixed slot size %d",
-                              slotOffset, chunkSize, fixedSlotSize)
-            );
-        }
-
-        setNextAddress(slotOffset, nextAddress);
-        Uns.putByte(address, slotOffset + ENTRY_OFF_KEY_LENGTH, (byte) key.length);
-        Uns.copyMemory(key, 0, address, slotOffset + ENTRY_OFF_DATA, key.length);
-        setValue(value, slotOffset);
-    }
-
-    void setValue(byte[] value, int slotOffset) {
-        if (value.length != fixedValueLength) {
-            throw new IllegalArgumentException(
-                String.format("Invalid value length. fixedValueLength %d, value length %d",
-                              fixedValueLength, value.length)
-            );
-        }
-
-        Uns.copyMemory(value, 0, address, slotOffset + ENTRY_OFF_DATA + fixedKeyLength, value.length);
+        return slotOffset;
     }
 
     int getWriteOffset() {
@@ -104,62 +78,98 @@ class MemoryPoolChunk {
         return chunkSize - writeOffset;
     }
 
-    ByteBuffer readOnlyValueByteBuffer(int offset) {
-        return Uns.directBufferFor(address, offset + ENTRY_OFF_DATA + fixedKeyLength, fixedValueLength, true);
+    // ---- next pointer ----
+
+    MemoryPoolAddress getNextAddress(int slotOffset) {
+        byte chunkIndex = Uns.getByte(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_INDEX);
+        int chunkOffset = Uns.getInt(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_OFFSET);
+        return new MemoryPoolAddress(chunkIndex, chunkOffset);
     }
 
-    ByteBuffer readOnlyKeyByteBuffer(int offset) {
-        return Uns.directBufferFor(address, offset + ENTRY_OFF_DATA, getKeyLength(offset), true);
+    void setNextAddress(int slotOffset, MemoryPoolAddress next) {
+        Uns.putByte(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_INDEX, next.chunkIndex);
+        Uns.putInt(address, slotOffset + ENTRY_OFF_NEXT_CHUNK_OFFSET, next.chunkOffset);
     }
 
-    long computeHash(int slotOffset, Hasher hasher) {
-        return hasher.hash(address, slotOffset + ENTRY_OFF_DATA, getKeyLength(slotOffset));
+    // ---- head slot: key length, inline key, value ----
+
+    int getKeyLength(int slotOffset) {
+        return Uns.getInt(address, slotOffset + ENTRY_OFF_KEY_LENGTH);
     }
 
+    void setKeyLength(int slotOffset, int keyLength) {
+        Uns.putInt(address, slotOffset + ENTRY_OFF_KEY_LENGTH, keyLength);
+    }
 
-    boolean compareKey(int slotOffset, byte[] key) {
-        if (key.length > fixedKeyLength || slotOffset + fixedSlotSize > chunkSize) {
-            throw new IllegalArgumentException("Invalid request. slotOffset - " + slotOffset + " key.length - " + key.length);
+    /** Write the first {@code length} bytes of {@code key} into the head slot's inline key region. */
+    void setInlineKey(int slotOffset, byte[] key, int length) {
+        Uns.copyMemory(key, 0, address, slotOffset + ENTRY_OFF_DATA, length);
+    }
+
+    void setValue(byte[] value, int slotOffset) {
+        if (value.length != fixedValueLength) {
+            throw new IllegalArgumentException(
+                String.format("Invalid value length. fixedValueLength %d, value length %d",
+                              fixedValueLength, value.length));
         }
+        Uns.copyMemory(value, 0, address, slotOffset + ENTRY_OFF_DATA + fixedKeyLength, value.length);
+    }
 
-        return getKeyLength(slotOffset) == key.length && compare(slotOffset + ENTRY_OFF_DATA, key);
+    /** Compare the first {@code length} bytes of {@code key} against the head slot's inline key. */
+    boolean compareInlineKey(int slotOffset, byte[] key, int length) {
+        return compare(slotOffset + ENTRY_OFF_DATA, key, 0, length);
     }
 
     boolean compareValue(int slotOffset, byte[] value) {
-        if (value.length != fixedValueLength || slotOffset + fixedSlotSize > chunkSize) {
-            throw new IllegalArgumentException("Invalid request. slotOffset - " + slotOffset + " value.length - " + value.length);
-        }
-
-        return compare(slotOffset + ENTRY_OFF_DATA + fixedKeyLength, value);
+        return compare(slotOffset + ENTRY_OFF_DATA + fixedKeyLength, value, 0, fixedValueLength);
     }
 
-    private boolean compare(int offset, byte[] array) {
-        int p = 0, length = array.length;
+    void readInlineKey(int slotOffset, byte[] dest, int destPos, int length) {
+        Uns.copyMemory(address, slotOffset + ENTRY_OFF_DATA, dest, destPos, length);
+    }
+
+    ByteBuffer readOnlyValueByteBuffer(int slotOffset) {
+        return Uns.directBufferFor(address, slotOffset + ENTRY_OFF_DATA + fixedKeyLength, fixedValueLength, true);
+    }
+
+    // ---- overflow slot: key fragment ----
+
+    /** Write {@code length} bytes of {@code key} starting at {@code keyPos} into an overflow slot. */
+    void setFragment(int slotOffset, byte[] key, int keyPos, int length) {
+        Uns.copyMemory(key, keyPos, address, slotOffset + ENTRY_OFF_FRAGMENT, length);
+    }
+
+    boolean compareFragment(int slotOffset, byte[] key, int keyPos, int length) {
+        return compare(slotOffset + ENTRY_OFF_FRAGMENT, key, keyPos, length);
+    }
+
+    void readFragment(int slotOffset, byte[] dest, int destPos, int length) {
+        Uns.copyMemory(address, slotOffset + ENTRY_OFF_FRAGMENT, dest, destPos, length);
+    }
+
+    /** Compare {@code length} bytes at {@code byteOffset} in this chunk with {@code array} from {@code arrayPos}. */
+    private boolean compare(int byteOffset, byte[] array, int arrayPos, int length) {
+        int p = 0;
         for (; length - p >= 8; p += 8) {
-            if (Uns.getLong(address, offset + p) != Uns.getLongFromByteArray(array, p)) {
+            if (Uns.getLong(address, byteOffset + p) != Uns.getLongFromByteArray(array, arrayPos + p)) {
                 return false;
             }
         }
         for (; length - p >= 4; p += 4) {
-            if (Uns.getInt(address, offset + p) != Uns.getIntFromByteArray(array, p)) {
+            if (Uns.getInt(address, byteOffset + p) != Uns.getIntFromByteArray(array, arrayPos + p)) {
                 return false;
             }
         }
         for (; length - p >= 2; p += 2) {
-            if (Uns.getShort(address, offset + p) != Uns.getShortFromByteArray(array, p)) {
+            if (Uns.getShort(address, byteOffset + p) != Uns.getShortFromByteArray(array, arrayPos + p)) {
                 return false;
             }
         }
         for (; length - p >= 1; p += 1) {
-            if (Uns.getByte(address, offset + p) != array[p]) {
+            if (Uns.getByte(address, byteOffset + p) != array[arrayPos + p]) {
                 return false;
             }
         }
-
         return true;
-    }
-
-    private byte getKeyLength(int slotOffset) {
-        return Uns.getByte(address, slotOffset + ENTRY_OFF_KEY_LENGTH);
     }
 }

--- a/src/main/java/com/oath/halodb/MemoryPoolHashEntries.java
+++ b/src/main/java/com/oath/halodb/MemoryPoolHashEntries.java
@@ -8,19 +8,34 @@ package com.oath.halodb;
 class MemoryPoolHashEntries {
 
     /*
-     * chunk index - 1 byte.
-     * chunk offset - 4 byte.
-     * key length - 1 byte.
+     * Every slot begins with a 5-byte "next" pointer (chunk index + chunk offset).
+     *
+     * A HEAD slot (the first slot of an entry) then holds:
+     *   chunk index  - 1 byte.
+     *   chunk offset - 4 byte.
+     *   key length   - 4 byte (int) — supports arbitrary-length keys.
+     *   inline key   - up to fixedKeyLength bytes (the first fixedKeyLength bytes of the key).
+     *   value        - fixedValueLength bytes.
+     *
+     * If the key is longer than fixedKeyLength, the remaining key bytes overflow into additional
+     * OVERFLOW slots chained via the same "next" pointer. An overflow slot reuses everything after
+     * its 5-byte next pointer as a key fragment:
+     *   chunk index  - 1 byte.
+     *   chunk offset - 4 byte.
+     *   key fragment - up to (slotSize - 5) bytes.
      */
-    static final int HEADER_SIZE = 1 + 4 + 1;
+    static final int HEADER_SIZE = 1 + 4 + 4;
 
     static final int ENTRY_OFF_NEXT_CHUNK_INDEX = 0;
     static final int ENTRY_OFF_NEXT_CHUNK_OFFSET = 1;
 
-    // offset of key length (1 bytes, byte)
+    // offset of key length in a head slot (4 bytes, int)
     static final int ENTRY_OFF_KEY_LENGTH = 5;
 
-    // offset of data in first block
-    static final int ENTRY_OFF_DATA = 6;
+    // offset of inline key/value data in a head slot
+    static final int ENTRY_OFF_DATA = 9;
+
+    // offset of the key fragment in an overflow slot (everything after the next pointer)
+    static final int ENTRY_OFF_FRAGMENT = 5;
 
 }

--- a/src/main/java/com/oath/halodb/NonMemoryPoolHashEntries.java
+++ b/src/main/java/com/oath/halodb/NonMemoryPoolHashEntries.java
@@ -15,15 +15,15 @@ final class NonMemoryPoolHashEntries {
     // offset of next hash entry in a hash bucket (8 bytes, long)
     static final long ENTRY_OFF_NEXT = 0;
 
-    // offset of key length (1 bytes, byte)
+    // offset of key length (4 bytes, int) — supports arbitrary-length keys
     static final long ENTRY_OFF_KEY_LENGTH = 8;
 
     // offset of data in first block
-    static final long ENTRY_OFF_DATA = 9;
+    static final long ENTRY_OFF_DATA = 12;
 
     static void init(int keyLen, long hashEntryAdr) {
         setNext(hashEntryAdr, 0L);
-        Uns.putByte(hashEntryAdr, ENTRY_OFF_KEY_LENGTH, (byte) keyLen);
+        Uns.putInt(hashEntryAdr, ENTRY_OFF_KEY_LENGTH, keyLen);
     }
 
     static long getNext(long hashEntryAdr) {
@@ -40,6 +40,6 @@ final class NonMemoryPoolHashEntries {
     }
 
     static int getKeyLen(long hashEntryAdr) {
-        return Uns.getByte(hashEntryAdr, ENTRY_OFF_KEY_LENGTH);
+        return Uns.getInt(hashEntryAdr, ENTRY_OFF_KEY_LENGTH);
     }
 }

--- a/src/main/java/com/oath/halodb/OffHeapHashTableImpl.java
+++ b/src/main/java/com/oath/halodb/OffHeapHashTableImpl.java
@@ -125,10 +125,6 @@ final class OffHeapHashTableImpl<V> implements OffHeapHashTable<V> {
             throw new IllegalArgumentException("old value size " + valueSize(old) + " greater than fixed value size " + fixedValueLength);
         }
 
-        if (key.length > Byte.MAX_VALUE) {
-            throw new IllegalArgumentException("key size of " + key.length + " exceeds max permitted size of " + Byte.MAX_VALUE);
-        }
-
         long hash = hasher.hash(key);
         return segment(hash).putEntry(key, value, hash, ifAbsent, old);
     }

--- a/src/main/java/com/oath/halodb/Record.java
+++ b/src/main/java/com/oath/halodb/Record.java
@@ -20,7 +20,7 @@ public class Record {
     public Record(byte[] key, byte[] value) {
         this.key = key;
         this.value = value;
-        header = new Header(0, Versions.CURRENT_DATA_FILE_VERSION, (byte)key.length, value.length, -1);
+        header = new Header(0, Versions.CURRENT_DATA_FILE_VERSION, key.length, value.length, -1);
     }
 
     ByteBuffer[] serialize() {
@@ -28,7 +28,7 @@ public class Record {
         return new ByteBuffer[] {headerBuf, ByteBuffer.wrap(key), ByteBuffer.wrap(value)};
     }
 
-    static Record deserialize(ByteBuffer buffer, short keySize, int valueSize) {
+    static Record deserialize(ByteBuffer buffer, int keySize, int valueSize) {
         buffer.flip();
         byte[] key = new byte[keySize];
         byte[] value = new byte[valueSize];
@@ -130,28 +130,28 @@ public class Record {
         /**
          * crc              - 4 bytes.
          * version          - 1 byte.
-         * key size         - 1 bytes.
+         * key size         - 4 bytes.
          * value size       - 4 bytes.
          * sequence number  - 8 bytes.
          */
         static final int CHECKSUM_OFFSET = 0;
         static final int VERSION_OFFSET = 4;
         static final int KEY_SIZE_OFFSET = 5;
-        static final int VALUE_SIZE_OFFSET = 6;
-        static final int SEQUENCE_NUMBER_OFFSET = 10;
+        static final int VALUE_SIZE_OFFSET = 9;
+        static final int SEQUENCE_NUMBER_OFFSET = 13;
 
-        static final int HEADER_SIZE = 18;
+        static final int HEADER_SIZE = 21;
         static final int CHECKSUM_SIZE = 4;
 
         private long checkSum;
         private int version;
-        private byte keySize;
+        private int keySize;
         private int valueSize;
         private long sequenceNumber;
 
         private int recordSize;
 
-        Header(long checkSum, int version, byte keySize, int valueSize, long sequenceNumber) {
+        Header(long checkSum, int version, int keySize, int valueSize, long sequenceNumber) {
             this.checkSum = checkSum;
             this.version = version;
             this.keySize = keySize;
@@ -164,7 +164,7 @@ public class Record {
 
             long checkSum = Utils.toUnsignedIntFromInt(buffer.getInt(CHECKSUM_OFFSET));
             int version = Utils.toUnsignedByte(buffer.get(VERSION_OFFSET));
-            byte keySize = buffer.get(KEY_SIZE_OFFSET);
+            int keySize = buffer.getInt(KEY_SIZE_OFFSET);
             int valueSize = buffer.getInt(VALUE_SIZE_OFFSET);
             long sequenceNumber = buffer.getLong(SEQUENCE_NUMBER_OFFSET);
 
@@ -176,7 +176,7 @@ public class Record {
             byte[] header = new byte[HEADER_SIZE];
             ByteBuffer headerBuffer = ByteBuffer.wrap(header);
             headerBuffer.put(VERSION_OFFSET, (byte)version);
-            headerBuffer.put(KEY_SIZE_OFFSET, keySize);
+            headerBuffer.putInt(KEY_SIZE_OFFSET, keySize);
             headerBuffer.putInt(VALUE_SIZE_OFFSET, valueSize);
             headerBuffer.putLong(SEQUENCE_NUMBER_OFFSET, sequenceNumber);
 
@@ -189,7 +189,7 @@ public class Record {
                    && header.recordSize > 0 && header.sequenceNumber > 0;
         }
 
-        byte getKeySize() {
+        int getKeySize() {
             return keySize;
         }
 

--- a/src/main/java/com/oath/halodb/SegmentWithMemoryPool.java
+++ b/src/main/java/com/oath/halodb/SegmentWithMemoryPool.java
@@ -91,11 +91,11 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
         try {
             for (MemoryPoolAddress address = table.getFirst(key.hash());
                  address.chunkIndex >= 0;
-                 address = getNext(address)) {
+                 address = nextEntry(address)) {
 
-                MemoryPoolChunk chunk = chunks.get(address.chunkIndex);
-                if (chunk.compareKey(address.chunkOffset, key.buffer)) {
+                if (entryKeyEquals(address, key.buffer)) {
                     hitCount++;
+                    MemoryPoolChunk chunk = chunks.get(address.chunkIndex);
                     return valueSerializer.deserialize(chunk.readOnlyValueByteBuffer(address.chunkOffset));
                 }
             }
@@ -113,10 +113,9 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
         try {
             for (MemoryPoolAddress address = table.getFirst(key.hash());
                  address.chunkIndex >= 0;
-                 address = getNext(address)) {
+                 address = nextEntry(address)) {
 
-                MemoryPoolChunk chunk = chunks.get(address.chunkIndex);
-                if (chunk.compareKey(address.chunkOffset, key.buffer)) {
+                if (entryKeyEquals(address, key.buffer)) {
                     hitCount++;
                     return true;
                 }
@@ -141,16 +140,16 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
             valueSerializer.serialize(value, newValueBuffer);
 
             MemoryPoolAddress first = table.getFirst(hash);
-            for (MemoryPoolAddress address = first; address.chunkIndex >= 0; address = getNext(address)) {
-                MemoryPoolChunk chunk = chunks.get(address.chunkIndex);
-                if (chunk.compareKey(address.chunkOffset, key)) {
-                    // key is already present in the segment. 
+            for (MemoryPoolAddress address = first; address.chunkIndex >= 0; address = nextEntry(address)) {
+                if (entryKeyEquals(address, key)) {
+                    // key is already present in the segment.
 
                     // putIfAbsent is true, but key is already present, return.
                     if (putIfAbsent) {
                         return false;
                     }
 
+                    MemoryPoolChunk chunk = chunks.get(address.chunkIndex);
                     // code for replace() operation
                     if (oldValue != null) {
                         if (!chunk.compareValue(address.chunkOffset, oldValueBuffer.array())) {
@@ -158,7 +157,7 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
                         }
                     }
 
-                    // replace value with the new one.
+                    // replace value with the new one (value always lives in the head slot).
                     chunk.setValue(newValueBuffer.array(), address.chunkOffset);
                     putReplaceCount++;
                     return true;
@@ -177,8 +176,8 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
             }
 
             // key is not present in the segment, we need to add a new entry.
-            MemoryPoolAddress nextSlot = writeToFreeSlot(key, newValueBuffer.array(), first);
-            table.addAsHead(hash, nextSlot);
+            MemoryPoolAddress head = writeToFreeSlots(key, newValueBuffer.array(), first);
+            table.addAsHead(hash, head);
             size++;
             putAddCount++;
         } finally {
@@ -195,10 +194,9 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
             MemoryPoolAddress previous = null;
             for (MemoryPoolAddress address = table.getFirst(key.hash());
                  address.chunkIndex >= 0;
-                 previous = address, address = getNext(address)) {
+                 previous = address, address = nextEntry(address)) {
 
-                MemoryPoolChunk chunk = chunks.get(address.chunkIndex);
-                if (chunk.compareKey(address.chunkOffset, key.buffer)) {
+                if (entryKeyEquals(address, key.buffer)) {
                     removeInternal(address, previous, key.hash());
                     removeCount++;
                     size--;
@@ -212,23 +210,108 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
         }
     }
 
-    private MemoryPoolAddress getNext(MemoryPoolAddress address) {
-        if (address.chunkIndex < 0 || address.chunkIndex >= chunks.size()) {
-            throw new IllegalArgumentException("Invalid chunk index " + address.chunkIndex + ". Chunk size " + chunks.size());
-        }
+    // ---- entry-level chain navigation ----
+    //
+    // An entry occupies 1 head slot plus N overflow slots (N>0 only for keys longer than
+    // fixedKeyLength), all linked by the per-slot next pointer: head -> frag1 -> ... -> fragN ->
+    // (next entry's head). So the raw slot chain interleaves entries and their fragments; the
+    // number of slots an entry spans is derived from its key length.
 
-        MemoryPoolChunk chunk = chunks.get(address.chunkIndex);
-        return chunk.getNextAddress(address.chunkOffset);
+    private int getKeyLen(MemoryPoolAddress head) {
+        return chunks.get(head.chunkIndex).getKeyLength(head.chunkOffset);
     }
 
-    private MemoryPoolAddress writeToFreeSlot(byte[] key, byte[] value, MemoryPoolAddress nextAddress) {
+    private MemoryPoolAddress rawNext(MemoryPoolAddress address) {
+        return chunks.get(address.chunkIndex).getNextAddress(address.chunkOffset);
+    }
+
+    /** Number of overflow slots a key of the given length needs (0 if it fits in the head slot). */
+    private int numOverflowSlots(int keyLength) {
+        if (keyLength <= fixedKeyLength) {
+            return 0;
+        }
+        int remaining = keyLength - fixedKeyLength;
+        int cap = fixedSlotSize - MemoryPoolHashEntries.ENTRY_OFF_FRAGMENT;
+        return (remaining + cap - 1) / cap;
+    }
+
+    /** Address of the next entry's head, skipping this entry's overflow slots. */
+    private MemoryPoolAddress nextEntry(MemoryPoolAddress head) {
+        int hops = numOverflowSlots(getKeyLen(head)) + 1;
+        MemoryPoolAddress a = head;
+        for (int i = 0; i < hops; i++) {
+            a = rawNext(a);
+        }
+        return a;
+    }
+
+    /** Address of this entry's last (tail) slot — the head itself when the key has no overflow. */
+    private MemoryPoolAddress tail(MemoryPoolAddress head) {
+        int hops = numOverflowSlots(getKeyLen(head));
+        MemoryPoolAddress a = head;
+        for (int i = 0; i < hops; i++) {
+            a = rawNext(a);
+        }
+        return a;
+    }
+
+    private boolean entryKeyEquals(MemoryPoolAddress head, byte[] key) {
+        MemoryPoolChunk chunk = chunks.get(head.chunkIndex);
+        int keyLen = chunk.getKeyLength(head.chunkOffset);
+        if (keyLen != key.length) {
+            return false;
+        }
+        if (keyLen <= fixedKeyLength) {
+            // fast path: whole key inline in the head slot.
+            return chunk.compareInlineKey(head.chunkOffset, key, keyLen);
+        }
+        // multi-slot key: compare the inline portion then each fragment.
+        if (!chunk.compareInlineKey(head.chunkOffset, key, fixedKeyLength)) {
+            return false;
+        }
+        int cap = fixedSlotSize - MemoryPoolHashEntries.ENTRY_OFF_FRAGMENT;
+        int pos = fixedKeyLength;
+        MemoryPoolAddress a = chunk.getNextAddress(head.chunkOffset);
+        while (pos < keyLen) {
+            MemoryPoolChunk c = chunks.get(a.chunkIndex);
+            int len = Math.min(cap, keyLen - pos);
+            if (!c.compareFragment(a.chunkOffset, key, pos, len)) {
+                return false;
+            }
+            pos += len;
+            a = c.getNextAddress(a.chunkOffset);
+        }
+        return true;
+    }
+
+    /** Reconstruct an entry's full key (used for rehashing; not on the lookup hot path). */
+    private byte[] readKey(MemoryPoolAddress head) {
+        MemoryPoolChunk chunk = chunks.get(head.chunkIndex);
+        int keyLen = chunk.getKeyLength(head.chunkOffset);
+        byte[] key = new byte[keyLen];
+        int inline = Math.min(keyLen, fixedKeyLength);
+        chunk.readInlineKey(head.chunkOffset, key, 0, inline);
+        int cap = fixedSlotSize - MemoryPoolHashEntries.ENTRY_OFF_FRAGMENT;
+        int pos = inline;
+        MemoryPoolAddress a = chunk.getNextAddress(head.chunkOffset);
+        while (pos < keyLen) {
+            MemoryPoolChunk c = chunks.get(a.chunkIndex);
+            int len = Math.min(cap, keyLen - pos);
+            c.readFragment(a.chunkOffset, key, pos, len);
+            pos += len;
+            a = c.getNextAddress(a.chunkOffset);
+        }
+        return key;
+    }
+
+    // ---- slot allocation ----
+
+    private MemoryPoolAddress allocateSlot() {
         if (!freeListHead.equals(emptyAddress)) {
-            // write to the head of the free list.
-            MemoryPoolAddress temp = freeListHead;
-            freeListHead = chunks.get(freeListHead.chunkIndex).getNextAddress(freeListHead.chunkOffset);
-            chunks.get(temp.chunkIndex).fillSlot(temp.chunkOffset, key, value, nextAddress);
+            MemoryPoolAddress slot = freeListHead;
+            freeListHead = chunks.get(slot.chunkIndex).getNextAddress(slot.chunkOffset);
             --freeListSize;
-            return temp;
+            return slot;
         }
 
         if (currentChunkIndex == -1 || chunks.get(currentChunkIndex).remaining() < fixedSlotSize) {
@@ -236,33 +319,75 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
                 logger.error("No more memory left. Each segment can have at most {} chunks.", Byte.MAX_VALUE + 1);
                 throw new OutOfMemoryError("Each segment can have at most " + (Byte.MAX_VALUE + 1) + " chunks.");
             }
-
-            // There is no chunk allocated for this segment or the current chunk being written to has no space left.
-            // allocate an new one. 
+            // No chunk allocated yet, or the current chunk has no room left: allocate a new one.
             chunks.add(MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength));
             ++currentChunkIndex;
         }
 
-        MemoryPoolChunk currentWriteChunk = chunks.get(currentChunkIndex);
-        MemoryPoolAddress slotAddress = new MemoryPoolAddress(currentChunkIndex, currentWriteChunk.getWriteOffset());
-        currentWriteChunk.fillNextSlot(key, value, nextAddress);
-        return slotAddress;
+        MemoryPoolChunk chunk = chunks.get(currentChunkIndex);
+        return new MemoryPoolAddress(currentChunkIndex, chunk.allocateSlot());
     }
 
-    private void removeInternal(MemoryPoolAddress address, MemoryPoolAddress previous, long hash) {
-        MemoryPoolAddress next = chunks.get(address.chunkIndex).getNextAddress(address.chunkOffset);
-        if (table.getFirst(hash).equals(address)) {
-            table.addAsHead(hash, next);
-        } else if (previous == null) {
-            //this should never happen. 
-            throw new IllegalArgumentException("Removing entry which is not head but with previous null");
-        } else {
-            chunks.get(previous.chunkIndex).setNextAddress(previous.chunkOffset, next);
+    /**
+     * Allocate the slots for an entry, write the key (inline portion + overflow fragments) and
+     * value, and chain them so the tail points at {@code nextAddress}. Returns the head address.
+     */
+    private MemoryPoolAddress writeToFreeSlots(byte[] key, byte[] value, MemoryPoolAddress nextAddress) {
+        int keyLen = key.length;
+        int overflow = numOverflowSlots(keyLen);
+
+        MemoryPoolAddress head = allocateSlot();
+        MemoryPoolChunk headChunk = chunks.get(head.chunkIndex);
+        headChunk.setKeyLength(head.chunkOffset, keyLen);
+        headChunk.setInlineKey(head.chunkOffset, key, Math.min(keyLen, fixedKeyLength));
+        headChunk.setValue(value, head.chunkOffset);
+
+        if (overflow == 0) {
+            headChunk.setNextAddress(head.chunkOffset, nextAddress);
+            return head;
         }
 
-        chunks.get(address.chunkIndex).setNextAddress(address.chunkOffset, freeListHead);
-        freeListHead = address;
-        ++freeListSize;
+        // Write the overflowing key bytes across chained slots.
+        int cap = fixedSlotSize - MemoryPoolHashEntries.ENTRY_OFF_FRAGMENT;
+        MemoryPoolAddress prev = head;
+        MemoryPoolChunk prevChunk = headChunk;
+        int pos = fixedKeyLength;
+        for (int i = 0; i < overflow; i++) {
+            MemoryPoolAddress slot = allocateSlot();
+            prevChunk.setNextAddress(prev.chunkOffset, slot);
+            MemoryPoolChunk chunk = chunks.get(slot.chunkIndex);
+            int len = Math.min(cap, keyLen - pos);
+            chunk.setFragment(slot.chunkOffset, key, pos, len);
+            pos += len;
+            prev = slot;
+            prevChunk = chunk;
+        }
+        prevChunk.setNextAddress(prev.chunkOffset, nextAddress);
+        return head;
+    }
+
+    private void removeInternal(MemoryPoolAddress head, MemoryPoolAddress previous, long hash) {
+        MemoryPoolAddress next = nextEntry(head);
+        if (table.getFirst(hash).equals(head)) {
+            table.addAsHead(hash, next);
+        } else if (previous == null) {
+            //this should never happen.
+            throw new IllegalArgumentException("Removing entry which is not head but with previous null");
+        } else {
+            // splice this entry out by pointing the previous entry's tail at our successor.
+            MemoryPoolAddress prevTail = tail(previous);
+            chunks.get(prevTail.chunkIndex).setNextAddress(prevTail.chunkOffset, next);
+        }
+
+        // return every slot of this entry (head + overflow) to the free list.
+        MemoryPoolAddress a = head;
+        while (!a.equals(next)) {
+            MemoryPoolAddress n = rawNext(a);
+            chunks.get(a.chunkIndex).setNextAddress(a.chunkOffset, freeListHead);
+            freeListHead = a;
+            ++freeListSize;
+            a = n;
+        }
     }
 
     private void rehash() {
@@ -278,12 +403,14 @@ class SegmentWithMemoryPool<V> extends Segment<V> {
         MemoryPoolAddress next;
 
         for (int i = 0; i < tableSize; i++) {
-            for (MemoryPoolAddress address = table.getFirst(i); address.chunkIndex >= 0; address = next) {
-                long hash = chunks.get(address.chunkIndex).computeHash(address.chunkOffset, hasher);
-                next = getNext(address);
+            for (MemoryPoolAddress head = table.getFirst(i); head.chunkIndex >= 0; head = next) {
+                next = nextEntry(head);
+                long hash = hasher.hash(readKey(head));
                 MemoryPoolAddress first = newTable.getFirst(hash);
-                newTable.addAsHead(hash, address);
-                chunks.get(address.chunkIndex).setNextAddress(address.chunkOffset, first);
+                newTable.addAsHead(hash, head);
+                // chain the rest of the new bucket onto this entry's tail slot.
+                MemoryPoolAddress t = tail(head);
+                chunks.get(t.chunkIndex).setNextAddress(t.chunkOffset, first);
             }
         }
 

--- a/src/main/java/com/oath/halodb/TombstoneEntry.java
+++ b/src/main/java/com/oath/halodb/TombstoneEntry.java
@@ -14,10 +14,10 @@ class TombstoneEntry {
     /**
      * crc              - 4 byte
      * version          - 1 byte
-     * Key size         - 1 byte
      * Sequence number  - 8 byte
+     * Key size         - 4 byte
      */
-    static final int TOMBSTONE_ENTRY_HEADER_SIZE = 4 + 1 + 1 + 8;
+    static final int TOMBSTONE_ENTRY_HEADER_SIZE = 4 + 1 + 8 + 4;
     static final int CHECKSUM_SIZE = 4;
 
     static final int CHECKSUM_OFFSET = 0;
@@ -58,11 +58,11 @@ class TombstoneEntry {
     }
 
     ByteBuffer[] serialize() {
-        byte keySize = (byte)key.length;
+        int keySize = key.length;
         ByteBuffer header = ByteBuffer.allocate(TOMBSTONE_ENTRY_HEADER_SIZE);
         header.put(VERSION_OFFSET, (byte)version);
         header.putLong(SEQUENCE_NUMBER_OFFSET, sequenceNumber);
-        header.put(KEY_SIZE_OFFSET, keySize);
+        header.putInt(KEY_SIZE_OFFSET, keySize);
         long crc32 = computeCheckSum(header.array());
         header.putInt(CHECKSUM_OFFSET, Utils.toSignedIntFromLong(crc32));
         return new ByteBuffer[] {header, ByteBuffer.wrap(key)};
@@ -72,7 +72,7 @@ class TombstoneEntry {
         long crc32 = Utils.toUnsignedIntFromInt(buffer.getInt());
         int version = Utils.toUnsignedByte(buffer.get());
         long sequenceNumber = buffer.getLong();
-        int keySize = (int)buffer.get();
+        int keySize = buffer.getInt();
         byte[] key = new byte[keySize];
         buffer.get(key);
 
@@ -88,7 +88,7 @@ class TombstoneEntry {
         long crc32 = Utils.toUnsignedIntFromInt(buffer.getInt());
         int version = Utils.toUnsignedByte(buffer.get());
         long sequenceNumber = buffer.getLong();
-        int keySize = (int)buffer.get();
+        int keySize = buffer.getInt();
         if (sequenceNumber < 0 || keySize <= 0 || version < 0 || version > 255 || buffer.remaining() < keySize)
             return null;
 
@@ -114,7 +114,7 @@ class TombstoneEntry {
         ByteBuffer header = ByteBuffer.allocate(TOMBSTONE_ENTRY_HEADER_SIZE);
         header.put(VERSION_OFFSET, (byte)version);
         header.putLong(SEQUENCE_NUMBER_OFFSET, sequenceNumber);
-        header.put(KEY_SIZE_OFFSET, (byte)key.length);
+        header.putInt(KEY_SIZE_OFFSET, key.length);
         return computeCheckSum(header.array());
     }
 }

--- a/src/main/java/com/oath/halodb/Versions.java
+++ b/src/main/java/com/oath/halodb/Versions.java
@@ -7,8 +7,10 @@ package com.oath.halodb;
 
 class Versions {
 
-    static final int CURRENT_DATA_FILE_VERSION = 0;
-    static final int CURRENT_INDEX_FILE_VERSION = 0;
-    static final int CURRENT_TOMBSTONE_FILE_VERSION = 0;
+    // Version 1 widened the key-size field from 1 byte to a 4-byte int in the data, index and
+    // tombstone formats to support arbitrary-length keys. Version-0 files are not readable.
+    static final int CURRENT_DATA_FILE_VERSION = 1;
+    static final int CURRENT_INDEX_FILE_VERSION = 1;
+    static final int CURRENT_TOMBSTONE_FILE_VERSION = 1;
     static final int CURRENT_META_FILE_VERSION = 0;
 }

--- a/src/test/java/com/oath/halodb/CrossCheckTest.java
+++ b/src/test/java/com/oath/halodb/CrossCheckTest.java
@@ -279,18 +279,17 @@ public class CrossCheckTest
 
     @Test(dataProvider = "hashAlgorithms", dependsOnMethods = "testBasics")
     public void testPutLargeKey(HashAlgorithm hashAlgorithm, boolean useMemoryPool) throws IOException, InterruptedException {
+        // 1024-byte key: far larger than the old 127-byte cap, and (for the memory pool) larger
+        // than fixedKeySize so it spans several chained slots. Both segments must round-trip it.
         byte[] key = HashTableTestUtils.randomBytes(1024);
         byte[] value = HashTableTestUtils.randomBytes(fixedValueSize);
 
         try (OffHeapHashTable<byte[]> cache = cache(hashAlgorithm, useMemoryPool, 1, -1)) {
-            if (useMemoryPool) {
-                // The memory pool requires keys <= fixedKeySize until slot-chaining lands (a later
-                // step); larger keys are rejected. The non-pool segment already supports any length.
-                Assert.assertThrows(IllegalArgumentException.class, () -> cache.put(key, value));
-            } else {
-                cache.put(key, value);
-                Assert.assertEquals(cache.get(key), value);
-            }
+            cache.put(key, value);
+            Assert.assertEquals(cache.get(key), value);
+            Assert.assertTrue(cache.containsKey(key));
+            Assert.assertTrue(cache.remove(key));
+            Assert.assertNull(cache.get(key));
         }
     }
 

--- a/src/test/java/com/oath/halodb/CrossCheckTest.java
+++ b/src/test/java/com/oath/halodb/CrossCheckTest.java
@@ -277,15 +277,20 @@ public class CrossCheckTest
         }
     }
 
-    @Test(dataProvider = "hashAlgorithms", dependsOnMethods = "testBasics",
-            expectedExceptions = IllegalArgumentException.class,
-            expectedExceptionsMessageRegExp = ".*exceeds max permitted size of 127")
-    public void testPutTooLargeKey(HashAlgorithm hashAlgorithm, boolean useMemoryPool) throws IOException, InterruptedException {
+    @Test(dataProvider = "hashAlgorithms", dependsOnMethods = "testBasics")
+    public void testPutLargeKey(HashAlgorithm hashAlgorithm, boolean useMemoryPool) throws IOException, InterruptedException {
         byte[] key = HashTableTestUtils.randomBytes(1024);
-        byte[] largeValue = HashTableTestUtils.randomBytes(fixedValueSize);
+        byte[] value = HashTableTestUtils.randomBytes(fixedValueSize);
 
         try (OffHeapHashTable<byte[]> cache = cache(hashAlgorithm, useMemoryPool, 1, -1)) {
-            cache.put(key, largeValue);
+            if (useMemoryPool) {
+                // The memory pool requires keys <= fixedKeySize until slot-chaining lands (a later
+                // step); larger keys are rejected. The non-pool segment already supports any length.
+                Assert.assertThrows(IllegalArgumentException.class, () -> cache.put(key, value));
+            } else {
+                cache.put(key, value);
+                Assert.assertEquals(cache.get(key), value);
+            }
         }
     }
 

--- a/src/test/java/com/oath/halodb/HaloDBLargeKeyTest.java
+++ b/src/test/java/com/oath/halodb/HaloDBLargeKeyTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018, Oath Inc
+ * Licensed under the terms of the Apache License 2.0. Please refer to accompanying LICENSE file for terms.
+ */
+
+package com.oath.halodb;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Exercises arbitrary-length keys (well beyond the old 127-byte cap) on both index implementations
+ * via the {@code Options} data provider. For the memory-pool variant the default {@code fixedKeySize}
+ * is 127, so keys larger than that span multiple chained slots.
+ */
+public class HaloDBLargeKeyTest extends TestBase {
+
+    // Sizes around the inline/overflow boundary (127) and several multi-slot sizes.
+    private static final int[] KEY_SIZES = {1, 8, 100, 127, 128, 200, 511, 1000, 4096, 16384};
+
+    private static byte[] uniqueKey(int size, Set<ByteBuffer> seen) {
+        byte[] key;
+        do {
+            key = TestUtils.generateRandomByteArray(size);
+        } while (!seen.add(ByteBuffer.wrap(key)));
+        return key;
+    }
+
+    @Test(dataProvider = "Options")
+    public void testVariousKeySizes(HaloDBOptions options) throws HaloDBException {
+        String directory = TestUtils.getTestDirectory("HaloDBLargeKeyTest", "testVariousKeySizes");
+        options.setCompactionDisabled(true);
+        HaloDB db = getTestDB(directory, options);
+
+        Random r = new Random(42);
+        Set<ByteBuffer> seen = new HashSet<>();
+        List<Record> records = new ArrayList<>();
+        for (int size : KEY_SIZES) {
+            byte[] key = uniqueKey(size, seen);
+            byte[] value = TestUtils.generateRandomByteArray(50 + r.nextInt(200));
+            db.put(key, value);
+            records.add(new Record(key, value));
+        }
+
+        // every key, including the multi-slot ones, reads back its value.
+        for (Record record : records) {
+            Assert.assertEquals(db.get(record.getKey()), record.getValue());
+            Assert.assertTrue(db.contains(record.getKey()));
+            Assert.assertEquals(db.valueSize(record.getKey()), record.getValue().length);
+        }
+
+        // update each key in place with a new value.
+        for (int i = 0; i < records.size(); i++) {
+            byte[] newValue = TestUtils.generateRandomByteArray(80);
+            db.put(records.get(i).getKey(), newValue);
+            records.set(i, new Record(records.get(i).getKey(), newValue));
+        }
+        for (Record record : records) {
+            Assert.assertEquals(db.get(record.getKey()), record.getValue());
+        }
+
+        // delete every other key; the rest must remain intact (verifies chain splicing).
+        for (int i = 0; i < records.size(); i += 2) {
+            db.delete(records.get(i).getKey());
+        }
+        for (int i = 0; i < records.size(); i++) {
+            if (i % 2 == 0) {
+                Assert.assertNull(db.get(records.get(i).getKey()));
+                Assert.assertFalse(db.contains(records.get(i).getKey()));
+            } else {
+                Assert.assertEquals(db.get(records.get(i).getKey()), records.get(i).getValue());
+            }
+        }
+    }
+
+    @Test(dataProvider = "Options")
+    public void testLargeKeysPersistAcrossReopen(HaloDBOptions options) throws HaloDBException {
+        String directory = TestUtils.getTestDirectory("HaloDBLargeKeyTest", "testLargeKeysPersistAcrossReopen");
+        options.setCompactionDisabled(true);
+        HaloDB db = getTestDB(directory, options);
+
+        Random r = new Random(7);
+        Set<ByteBuffer> seen = new HashSet<>();
+        List<Record> records = new ArrayList<>();
+        for (int size : KEY_SIZES) {
+            byte[] key = uniqueKey(size, seen);
+            byte[] value = TestUtils.generateRandomByteArray(64 + r.nextInt(64));
+            db.put(key, value);
+            records.add(new Record(key, value));
+        }
+
+        // delete one large key so a tombstone with a long key must also round-trip on reopen.
+        byte[] deletedKey = records.get(records.size() - 1).getKey();
+        db.delete(deletedKey);
+
+        // reopen: the in-memory index is rebuilt from the .index/.tombstone files.
+        db.close();
+        db = getTestDBWithoutDeletingFiles(directory, options);
+
+        for (int i = 0; i < records.size() - 1; i++) {
+            Assert.assertEquals(db.get(records.get(i).getKey()), records.get(i).getValue());
+        }
+        Assert.assertNull(db.get(deletedKey));
+    }
+
+    @Test(dataProvider = "Options")
+    public void testManyLargeKeysWithRehash(HaloDBOptions options) throws HaloDBException {
+        // Insert enough large (multi-slot) keys to force the off-heap index to rehash, then verify
+        // every key is still retrievable — exercising rehash over multi-slot entries.
+        String directory = TestUtils.getTestDirectory("HaloDBLargeKeyTest", "testManyLargeKeysWithRehash");
+        options.setCompactionDisabled(true);
+        HaloDB db = getTestDB(directory, options);
+
+        int count = 5000;
+        Random r = new Random(99);
+        Set<ByteBuffer> seen = new HashSet<>();
+        List<Record> records = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            byte[] key = uniqueKey(150 + r.nextInt(400), seen); // always > 127 -> multi-slot
+            byte[] value = TestUtils.generateRandomByteArray(32);
+            db.put(key, value);
+            records.add(new Record(key, value));
+        }
+
+        Assert.assertEquals(db.size(), count);
+        for (Record record : records) {
+            Assert.assertEquals(db.get(record.getKey()), record.getValue());
+        }
+
+        // remove half and confirm the rest survive (chain splicing under load).
+        for (int i = 0; i < count; i += 2) {
+            db.delete(records.get(i).getKey());
+        }
+        for (int i = 0; i < count; i++) {
+            if (i % 2 == 0) {
+                Assert.assertNull(db.get(records.get(i).getKey()));
+            } else {
+                Assert.assertEquals(db.get(records.get(i).getKey()), records.get(i).getValue());
+            }
+        }
+    }
+}

--- a/src/test/java/com/oath/halodb/IndexFileEntryTest.java
+++ b/src/test/java/com/oath/halodb/IndexFileEntryTest.java
@@ -20,13 +20,13 @@ public class IndexFileEntryTest {
         byte[] key = TestUtils.generateRandomByteArray(8);
         int recordSize = 1024;
         int recordOffset = 10240;
-        byte keySize = (byte) key.length;
+        int keySize = key.length;
         long sequenceNumber = 100;
         int version = 200;
 
         ByteBuffer header = ByteBuffer.allocate(INDEX_FILE_HEADER_SIZE);
         header.put(VERSION_OFFSET, (byte)version);
-        header.put(KEY_SIZE_OFFSET, keySize);
+        header.putInt(KEY_SIZE_OFFSET, keySize);
         header.putInt(RECORD_SIZE_OFFSET, recordSize);
         header.putInt(RECORD_OFFSET, recordOffset);
         header.putLong(SEQUENCE_NUMBER_OFFSET, sequenceNumber);
@@ -49,7 +49,7 @@ public class IndexFileEntryTest {
         byte[] key = TestUtils.generateRandomByteArray(8);
         int recordSize = 1024;
         int recordOffset = 10240;
-        byte keySize = (byte) key.length;
+        int keySize = key.length;
         long sequenceNumber = 100;
         int version = 10;
         long checksum = 42323;
@@ -57,7 +57,7 @@ public class IndexFileEntryTest {
         ByteBuffer header = ByteBuffer.allocate(IndexFileEntry.INDEX_FILE_HEADER_SIZE + keySize);
         header.putInt((int)checksum);
         header.put((byte)version);
-        header.put(keySize);
+        header.putInt(keySize);
         header.putInt(recordSize);
         header.putInt(recordOffset);
         header.putLong(sequenceNumber);

--- a/src/test/java/com/oath/halodb/MemoryPoolChunkTest.java
+++ b/src/test/java/com/oath/halodb/MemoryPoolChunkTest.java
@@ -11,6 +11,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Random;
 
 public class MemoryPoolChunkTest {
@@ -25,138 +26,89 @@ public class MemoryPoolChunkTest {
     }
 
     @Test
-    public void testSetAndGetMethods() {
+    public void testAllocateSlot() {
         int chunkSize = 16 * 1024;
         int fixedKeyLength = 12, fixedValueLength = 20;
         int slotSize = MemoryPoolHashEntries.HEADER_SIZE + fixedKeyLength + fixedValueLength;
 
         chunk = MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength);
-        int offset = chunk.getWriteOffset();
-
-        Assert.assertEquals(chunk.remaining(), chunkSize);
         Assert.assertEquals(chunk.getWriteOffset(), 0);
+        Assert.assertEquals(chunk.remaining(), chunkSize);
 
-        // write to an empty slot.
-        byte[] key = Longs.toByteArray(101);
-        byte[] value = HashTableTestUtils.randomBytes(fixedValueLength);
-        MemoryPoolAddress nextAddress = new MemoryPoolAddress((byte) 10, 34343);
-        chunk.fillNextSlot(key, value, nextAddress);
+        int first = chunk.allocateSlot();
+        Assert.assertEquals(first, 0);
+        Assert.assertEquals(chunk.getWriteOffset(), slotSize);
+        Assert.assertEquals(chunk.remaining(), chunkSize - slotSize);
 
-        Assert.assertEquals(chunk.getWriteOffset(), offset + slotSize);
-        Assert.assertEquals(chunk.remaining(), chunkSize-slotSize);
-        Assert.assertTrue(chunk.compareKey(offset, key));
-        Assert.assertTrue(chunk.compareValue(offset, value));
-
-        MemoryPoolAddress actual = chunk.getNextAddress(offset);
-        Assert.assertEquals(actual.chunkIndex, nextAddress.chunkIndex);
-        Assert.assertEquals(actual.chunkOffset, nextAddress.chunkOffset);
-
-        // write to the next empty slot.
-        byte[] key2 = HashTableTestUtils.randomBytes(fixedKeyLength);
-        byte[] value2 = HashTableTestUtils.randomBytes(fixedValueLength);
-        MemoryPoolAddress nextAddress2 = new MemoryPoolAddress((byte) 0, 4454545);
-        chunk.fillNextSlot(key2, value2, nextAddress2);
-        Assert.assertEquals(chunk.getWriteOffset(), offset + 2*slotSize);
-        Assert.assertEquals(chunk.remaining(), chunkSize-2*slotSize);
-
-        offset += slotSize;
-        Assert.assertTrue(chunk.compareKey(offset, key2));
-        Assert.assertTrue(chunk.compareValue(offset, value2));
-
-        actual = chunk.getNextAddress(offset);
-        Assert.assertEquals(actual.chunkIndex, nextAddress2.chunkIndex);
-        Assert.assertEquals(actual.chunkOffset, nextAddress2.chunkOffset);
-
-        // update an existing slot.
-        byte[] key3 = Longs.toByteArray(0x64735981289L);
-        byte[] value3 = HashTableTestUtils.randomBytes(fixedValueLength);
-        MemoryPoolAddress nextAddress3 = new MemoryPoolAddress((byte)-1, -1);
-        chunk.fillSlot(0, key3, value3, nextAddress3);
-
-        offset = 0;
-        Assert.assertTrue(chunk.compareKey(offset, key3));
-        Assert.assertTrue(chunk.compareValue(offset, value3));
-
-        // write offset should remain unchanged.
-        Assert.assertEquals(chunk.getWriteOffset(), offset + 2*slotSize);
-        Assert.assertEquals(chunk.remaining(), chunkSize-2*slotSize);
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid offset.*")
-    public void testWithInvalidOffset() {
-        int chunkSize = 256;
-        int fixedKeyLength = 100, fixedValueLength = 100;
-        MemoryPoolAddress next = new MemoryPoolAddress((byte)-1, -1);
-        chunk = MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength);
-        chunk.fillSlot(chunkSize - 5, HashTableTestUtils.randomBytes(fixedKeyLength), HashTableTestUtils.randomBytes(fixedValueLength), next);
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid request. Key length.*")
-    public void testWithInvalidKey() {
-        int chunkSize = 256;
-        int fixedKeyLength = 32, fixedValueLength = 100;
-        MemoryPoolAddress next = new MemoryPoolAddress((byte)-1, -1);
-        chunk = MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength);
-        chunk.fillSlot(chunkSize - 5, HashTableTestUtils.randomBytes(fixedKeyLength + 10), HashTableTestUtils.randomBytes(fixedValueLength), next);
+        int second = chunk.allocateSlot();
+        Assert.assertEquals(second, slotSize);
+        Assert.assertEquals(chunk.getWriteOffset(), 2 * slotSize);
     }
 
     @Test
-    public void testCompare() {
-        int chunkSize = 1024;
-        int fixedKeyLength = 9, fixedValueLength = 15;
+    public void testHeadSlotKeyValue() {
+        int chunkSize = 16 * 1024;
+        int fixedKeyLength = 12, fixedValueLength = 20;
 
         chunk = MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength);
-        byte[] key = HashTableTestUtils.randomBytes(fixedKeyLength);
+        int offset = chunk.allocateSlot();
+
+        byte[] key = Longs.toByteArray(101); // 8 bytes, fits inline
         byte[] value = HashTableTestUtils.randomBytes(fixedValueLength);
-        int offset = 0;
-        chunk.fillSlot(offset, key, value, new MemoryPoolAddress((byte)-1, -1));
+        MemoryPoolAddress next = new MemoryPoolAddress((byte) 10, 34343);
 
-        Assert.assertTrue(chunk.compareKey(offset, key));
+        chunk.setKeyLength(offset, key.length);
+        chunk.setInlineKey(offset, key, key.length);
+        chunk.setValue(value, offset);
+        chunk.setNextAddress(offset, next);
+
+        Assert.assertEquals(chunk.getKeyLength(offset), key.length);
+        Assert.assertTrue(chunk.compareInlineKey(offset, key, key.length));
         Assert.assertTrue(chunk.compareValue(offset, value));
+        Assert.assertEquals(chunk.getNextAddress(offset), next);
 
-        byte[] smallKey = new byte[key.length-1];
-        System.arraycopy(key, 0, smallKey, 0, smallKey.length);
-        Assert.assertFalse(chunk.compareKey(offset, smallKey));
+        byte[] readKey = new byte[key.length];
+        chunk.readInlineKey(offset, readKey, 0, key.length);
+        Assert.assertEquals(readKey, key);
 
-        key[fixedKeyLength-1] = (byte)~key[fixedKeyLength-1];
-        Assert.assertFalse(chunk.compareKey(offset, key));
+        ByteBuffer valueBuf = chunk.readOnlyValueByteBuffer(offset);
+        byte[] readValue = new byte[fixedValueLength];
+        valueBuf.get(readValue);
+        Assert.assertEquals(readValue, value);
 
-        value[0] = (byte)~value[0];
+        // a differing key/value must not compare equal.
+        byte[] otherKey = Longs.toByteArray(102);
+        Assert.assertFalse(chunk.compareInlineKey(offset, otherKey, otherKey.length));
+        value[0] = (byte) ~value[0];
         Assert.assertFalse(chunk.compareValue(offset, value));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid request.*")
-    public void testCompareKeyWithException() {
-        int chunkSize = 1024;
-        Random r = new Random();
-        int fixedKeyLength = 1 + r.nextInt(100), fixedValueLength = 1 + r.nextInt(100);
-        
-        chunk = MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength);
-        byte[] key = HashTableTestUtils.randomBytes(fixedKeyLength);
-        byte[] value = HashTableTestUtils.randomBytes(fixedValueLength);
-        int offset = 0;
-        chunk.fillSlot(offset, key, value, new MemoryPoolAddress((byte)-1, -1));
-
-        byte[] bigKey = HashTableTestUtils.randomBytes(fixedKeyLength + 1);
-        chunk.compareKey(offset, bigKey);
-
-
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Invalid request.*")
-    public void testCompareValueWithException() {
-        int chunkSize = 1024;
-        Random r = new Random();
-        int fixedKeyLength = 1 + r.nextInt(100), fixedValueLength = 1 + r.nextInt(100);
+    @Test
+    public void testOverflowFragment() {
+        int chunkSize = 16 * 1024;
+        int fixedKeyLength = 8, fixedValueLength = 20;
 
         chunk = MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength);
-        byte[] key = HashTableTestUtils.randomBytes(fixedKeyLength);
-        byte[] value = HashTableTestUtils.randomBytes(fixedValueLength);
-        int offset = 0;
-        chunk.fillSlot(offset, key, value, new MemoryPoolAddress((byte)-1, -1));
+        int offset = chunk.allocateSlot();
+        int cap = chunk.fragmentCapacity();
 
-        byte[] bigValue = HashTableTestUtils.randomBytes(fixedValueLength + 1);
-        chunk.compareValue(offset, bigValue);
+        // a fragment is an arbitrary slice of a key written after the next pointer.
+        byte[] key = HashTableTestUtils.randomBytes(cap);
+        chunk.setFragment(offset, key, 0, cap);
+
+        Assert.assertTrue(chunk.compareFragment(offset, key, 0, cap));
+
+        byte[] readBack = new byte[cap];
+        chunk.readFragment(offset, readBack, 0, cap);
+        Assert.assertEquals(readBack, key);
+
+        // partial fragment from a non-zero key position.
+        byte[] longKey = HashTableTestUtils.randomBytes(cap + fixedKeyLength);
+        chunk.setFragment(offset, longKey, fixedKeyLength, cap);
+        Assert.assertTrue(chunk.compareFragment(offset, longKey, fixedKeyLength, cap));
+
+        longKey[fixedKeyLength] = (byte) ~longKey[fixedKeyLength];
+        Assert.assertFalse(chunk.compareFragment(offset, longKey, fixedKeyLength, cap));
     }
 
     @Test
@@ -167,11 +119,10 @@ public class MemoryPoolChunkTest {
 
         chunk = MemoryPoolChunk.create(chunkSize, fixedKeyLength, fixedValueLength);
 
-        MemoryPoolAddress nextAddress = new MemoryPoolAddress((byte)r.nextInt(Byte.MAX_VALUE), r.nextInt());
+        MemoryPoolAddress nextAddress = new MemoryPoolAddress((byte) r.nextInt(Byte.MAX_VALUE), r.nextInt());
         int offset = r.nextInt(chunkSize - fixedKeyLength - fixedValueLength - MemoryPoolHashEntries.HEADER_SIZE);
         chunk.setNextAddress(offset, nextAddress);
 
         Assert.assertEquals(chunk.getNextAddress(offset), nextAddress);
-
     }
 }

--- a/src/test/java/com/oath/halodb/RecordTest.java
+++ b/src/test/java/com/oath/halodb/RecordTest.java
@@ -16,7 +16,7 @@ public class RecordTest {
     @Test
     public void testSerializeHeader() {
 
-        byte keySize = 8;
+        int keySize = 8;
         int valueSize = 100;
         long sequenceNumber = 34543434343L;
         int version = 128;
@@ -24,7 +24,7 @@ public class RecordTest {
         Record.Header header = new Record.Header(0, version, keySize, valueSize, sequenceNumber);
         ByteBuffer serialized = header.serialize();
 
-        Assert.assertEquals(keySize, serialized.get(Record.Header.KEY_SIZE_OFFSET));
+        Assert.assertEquals(keySize, serialized.getInt(Record.Header.KEY_SIZE_OFFSET));
         Assert.assertEquals(valueSize, serialized.getInt(Record.Header.VALUE_SIZE_OFFSET));
         Assert.assertEquals(sequenceNumber, serialized.getLong(Record.Header.SEQUENCE_NUMBER_OFFSET));
         Assert.assertEquals(Utils.toUnsignedByte(serialized.get(Record.Header.VERSION_OFFSET)), version);
@@ -34,7 +34,7 @@ public class RecordTest {
     public void testDeserializeHeader() {
 
         long checkSum = 23434;
-        byte keySize = 8;
+        int keySize = 8;
         int valueSize = 100;
         long sequenceNumber = 34543434343L;
         int version = 2;
@@ -42,7 +42,7 @@ public class RecordTest {
         ByteBuffer buffer = ByteBuffer.allocate(Record.Header.HEADER_SIZE);
         buffer.putInt(Utils.toSignedIntFromLong(checkSum));
         buffer.put((byte)version);
-        buffer.put(keySize);
+        buffer.putInt(keySize);
         buffer.putInt(valueSize);
         buffer.putLong(sequenceNumber);
         buffer.flip();
@@ -74,7 +74,7 @@ public class RecordTest {
         crc32.update(key);
         crc32.update(value);
 
-        Record.Header header = new Record.Header(0, version, (byte)key.length, value.length, sequenceNumber);
+        Record.Header header = new Record.Header(0, version, key.length, value.length, sequenceNumber);
         ByteBuffer headerBuf = header.serialize();
         headerBuf.putInt(Record.Header.CHECKSUM_OFFSET, Utils.toSignedIntFromLong(crc32.getValue()));
 

--- a/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
+++ b/src/test/java/com/oath/halodb/TombstoneFileCleanUpTest.java
@@ -209,7 +209,9 @@ public class TombstoneFileCleanUpTest extends TestBase {
         int noOfFiles = 8;
         int noOfRecords = noOfRecordsPerFile * noOfFiles;
 
-        int keyLength = 18;
+        // keyLength chosen so record (21 + 15 + 24 = 60) and tombstone entry (17 + 15 = 32) sizes
+        // match the file-packing arithmetic this test relies on after the key-size field widened.
+        int keyLength = 15;
         int valueLength = 24;
 
         List<Record> records = new ArrayList<>();
@@ -228,7 +230,7 @@ public class TombstoneFileCleanUpTest extends TestBase {
         db.close();
         db = getTestDBWithoutDeletingFiles(directory, options);
 
-        // Since keyLength was 18, plus header length 14, tombstone entry is 32 bytes.
+        // Since keyLength was 15, plus header length 17, tombstone entry is 32 bytes.
         // Since file size is 512 there would be two tombstone files both of which should be copied.
         File[] tombstoneFiles = FileUtils.listTombstoneFiles(new File(directory));
         Set<String> tombstones = new HashSet<>();
@@ -260,14 +262,14 @@ public class TombstoneFileCleanUpTest extends TestBase {
         options.setMaxTombstoneFileSize(2 * 1024);
         HaloDB db = getTestDB(directory, options);
 
-        // Record size: header 18 + key 18 + value 28 = 64 bytes
-        // Tombstone entry size: header 14 + key 18 = 32 bytes
+        // Record size: header 21 + key 15 + value 28 = 64 bytes
+        // Tombstone entry size: header 17 + key 15 = 32 bytes
         // Each data file will store 16 * 1024 / 64 = 256 records
         // Each tombstone file will store 2 * 1024 / 32 = 64 entries
         // Total data files 2048 / 256 = 8
         // Total tombstone original file count (1024 / 2 + 1024 / 4) / 64 = 12
         // After cleanup, tombstone file count 1024 / 4 / 64 = 4
-        int keyLength = 18;
+        int keyLength = 15;
         int valueLength = 28;
         int noOfRecords = 2048;
         List<Record> records = new ArrayList<>();


### PR DESCRIPTION
## What & why

HaloDB capped keys at **127 bytes** (`Byte.MAX_VALUE`) — an artificial limit baked into the storage encoding (every persisted and in-memory structure stored key length in a single signed byte). This is a real adoption blocker versus RocksDB, since many natural keys (URLs, composite keys, paths, namespaced IDs) exceed 127 bytes.

This PR removes the cap: **keys may now be any length on both index implementations.**

## How (three reviewable commits)

1. **On-disk format** — key-size field widened 1 byte → 4-byte int in the data, index and tombstone headers. File-format version bumped 0 → 1.
2. **Non-pool segment** (the default) — key length stored as a 4-byte int; the 127-byte cap removed. Arbitrary keys "just work" since entries are already variably sized.
3. **Memory-pool segment** — keys longer than `fixedKeySize` overflow into additional slots chained by the per-slot next pointer (head slot holds the inline key prefix + value; fragment slots hold the rest). Keys within `fixedKeySize` stay **single-slot on the hot path**, gated by one `keyLen <= fixedKeySize` branch. Adds entry-level chain navigation, multi-slot alloc/free, and key reconstruction for rehashing. `fixedKeySize` is now just the inline slot size (no upper bound beyond fitting a chunk).

The ordered (ART) index still requires fixed-length keys — unchanged.

## ⚠️ Breaking change

The on-disk format changes (version 0 → 1). **Databases written before 0.7 are not readable and must be rebuilt.** No dual-format reader is provided.

## Verification

- **Full suite: 287 passed, 0 failed, 1 skipped.**
- New `HaloDBLargeKeyTest` exercises **both** index implementations via the `Options` data provider: boundary sizes (1 / 127 / 128 / multi-KB), multi-slot keys, update/delete, reopen (index rebuilt from `.index`/`.tombstone`), and **rehash with 5,000 multi-slot keys**.
- `CrossCheckTest` validates the memory-pool chaining against the on-heap reference implementation for 1024-byte keys (put/get/contains/remove).

### Performance — no regression on the 8-byte hot path

The benchmark drives the memory pool with `fixedKeySize=8`. Measured master vs this branch back-to-back, interleaved at the same thermal state:

| metric | master (avg) | branch (avg) |
| --- | ---: | ---: |
| WRITE ops/sec | 332,469 | 329,657 |
| READ ops/sec | ~2.98M | ~2.86M |
| READ p50 | 2.2 µs | 2.1–2.3 µs |
| PREFIX keys/sec | ~1.08M | ~1.08M |

Differences are within run-to-run noise (sub-1% on WRITE; the branch was faster than master in one round). Small keys are unaffected because they stay single-slot — the only added hot-path work is reading the key length as an int and one predictable branch.