### PR TITLE
Always release the db file lock on close (fix test-isolation flakiness)

### DIFF
--- a/src/main/java/com/oath/halodb/HaloDBInternal.java
+++ b/src/main/java/com/oath/halodb/HaloDBInternal.java
@@ -169,48 +169,56 @@ class HaloDBInternal {
             isClosing = true;
 
             try {
-                if(!compactionManager.stopCompactionThread(true))
-                    setIOErrorFlag();
-            } catch (IOException e) {
-                logger.error("Error while stopping compaction thread. Setting IOError flag", e);
-                setIOErrorFlag();
-            }
-
-            if (isTombstoneFilesMerging) {
                 try {
-                    tombstoneMergeThread.join();
-                } catch (InterruptedException e) {
-                    logger.error("Interrupted when waiting the tombstone files merging");
+                    if(!compactionManager.stopCompactionThread(true))
+                        setIOErrorFlag();
+                } catch (IOException e) {
+                    logger.error("Error while stopping compaction thread. Setting IOError flag", e);
                     setIOErrorFlag();
                 }
-            }
 
-            if (options.isCleanUpInMemoryIndexOnClose())
-                inMemoryIndex.close();
+                if (isTombstoneFilesMerging) {
+                    try {
+                        tombstoneMergeThread.join();
+                    } catch (InterruptedException e) {
+                        logger.error("Interrupted when waiting the tombstone files merging");
+                        setIOErrorFlag();
+                    }
+                }
 
-            if (currentWriteFile != null) {
-                currentWriteFile.flushToDisk();
-                currentWriteFile.getIndexFile().flushToDisk();
-                currentWriteFile.close();
-            }
-            if (currentTombstoneFile != null) {
-                currentTombstoneFile.flushToDisk();
-                currentTombstoneFile.close();
-            }
+                if (options.isCleanUpInMemoryIndexOnClose())
+                    inMemoryIndex.close();
 
-            for (HaloDBFile file : readFileMap.values()) {
-                file.close();
-            }
+                if (currentWriteFile != null) {
+                    currentWriteFile.flushToDisk();
+                    currentWriteFile.getIndexFile().flushToDisk();
+                    currentWriteFile.close();
+                }
+                if (currentTombstoneFile != null) {
+                    currentTombstoneFile.flushToDisk();
+                    currentTombstoneFile.close();
+                }
 
-            DBMetaData metaData = new DBMetaData(dbDirectory);
-            metaData.loadFromFileIfExists();
-            metaData.setOpen(false);
-            metaData.storeToFile();
+                for (HaloDBFile file : readFileMap.values()) {
+                    file.close();
+                }
 
-            dbDirectory.close();
+                DBMetaData metaData = new DBMetaData(dbDirectory);
+                metaData.loadFromFileIfExists();
+                metaData.setOpen(false);
+                metaData.storeToFile();
 
-            if (dbLock != null) {
-                dbLock.close();
+                dbDirectory.close();
+            } finally {
+                // Always release the inter-process file lock, even if flushing or closing the files
+                // above threw (e.g. a channel closed by an interrupted IO thread, or an injected
+                // fault). A FileLock is JVM-wide per file, so a lingering lock would make the next
+                // open of this directory fail with "Another process already holds a lock" — the
+                // root of an intermittent test-isolation failure.
+                if (dbLock != null) {
+                    dbLock.close();
+                    dbLock = null;
+                }
             }
         } finally {
             writeLock.unlock();

--- a/src/test/java/com/oath/halodb/HaloDBTest.java
+++ b/src/test/java/com/oath/halodb/HaloDBTest.java
@@ -16,6 +16,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.file.Paths;
 
+import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 
@@ -486,6 +487,43 @@ public class HaloDBTest extends TestBase {
         HaloDB anotherDB = getTestDBWithoutDeletingFiles(directory, new HaloDBOptions());
         anotherDB.put(Longs.toByteArray(1), Longs.toByteArray(1));
         Assert.assertEquals(anotherDB.size(), 1);
+    }
+
+    @Test
+    public void testLockReleasedWhenCloseFails() throws Throwable {
+        // If close() fails partway through (here: an injected IOException while persisting metadata),
+        // the inter-process file lock must still be released so the same directory can be reopened.
+        // This guards against the lock leak that caused intermittent "Another process already holds
+        // a lock" test-isolation failures.
+        final boolean[] failClose = {false};
+        new MockUp<DBMetaData>() {
+            @Mock
+            void storeToFile(Invocation inv) throws IOException {
+                if (failClose[0]) {
+                    throw new IOException("injected failure while closing");
+                }
+                inv.proceed(); // real behaviour during open()
+            }
+        };
+
+        String directory = TestUtils.getTestDirectory("HaloDBTest", "testLockReleasedWhenCloseFails");
+        HaloDB db = getTestDB(directory, new HaloDBOptions());
+        db.put(Longs.toByteArray(1), Longs.toByteArray(1));
+
+        failClose[0] = true;
+        try {
+            db.close();
+            Assert.fail("close() was expected to fail");
+        } catch (HaloDBException expected) {
+            // close failed as injected — the lock must nonetheless have been released.
+        }
+
+        // Reopening the same directory must succeed (it would throw "Another process already holds a
+        // lock" if the lock had leaked).
+        failClose[0] = false;
+        HaloDB reopened = getTestDBWithoutDeletingFiles(directory, new HaloDBOptions());
+        reopened.put(Longs.toByteArray(2), Longs.toByteArray(2));
+        Assert.assertEquals(reopened.size(), 2);
     }
 
     @Test(expectedExceptions = HaloDBException.class)

--- a/src/test/java/com/oath/halodb/TestBase.java
+++ b/src/test/java/com/oath/halodb/TestBase.java
@@ -61,14 +61,22 @@ public class TestBase {
     @AfterMethod(alwaysRun = true)
     public void closeDB() throws HaloDBException, IOException {
         if (db != null) {
-            db.close();
-            db = null;
-            File dir = new File(directory);
-            if (dbDirectory != null) {
-                dbDirectory.close();
-                dbDirectory = null;
+            try {
+                db.close();
+            } finally {
+                // Always tear down, even if close() failed (or an injected fault threw), so the
+                // next test starts from a clean slate and cannot inherit a half-closed db.
+                db = null;
+                if (dbDirectory != null) {
+                    try {
+                        dbDirectory.close();
+                    } catch (IOException ignored) {
+                        // best effort; the directory is deleted next anyway.
+                    }
+                    dbDirectory = null;
+                }
+                TestUtils.deleteDirectory(new File(directory));
             }
-            TestUtils.deleteDirectory(dir);
         }
     }
 }


### PR DESCRIPTION
## Problem

CI intermittently failed on **Java 22** with `Another process already holds a lock to this db` — a test-isolation flake that didn't reproduce locally and also affected `master`.

## Root cause

`HaloDBInternal.close()` released the inter-process file lock (`dbLock.close()`) as its **last** statement, unprotected. If anything earlier in `close()` threw — a `flushToDisk` hitting a channel closed by an interrupted IO thread under load, or a fault injected by one of the mock-based tests — the lock release was skipped. A `FileLock` is **JVM-wide per file**, so the lingering lock made the *next* open of that directory throw `OverlappingFileLockException` → the flake's error. The 3 tests added in #17 widened the timing window enough to make it fail consistently on the slower CI runners.

## Fix

- **`HaloDBInternal.close()`** now releases the lock in a `finally`, so it's always released even if flushing/closing files throws. This is a genuine correctness fix, not a test workaround.
- **`TestBase.closeDB()`** tears down (close directory, delete files, drop handle) in a `finally`, so a failing `close()` can't leak state into the next test.
- **New `HaloDBTest.testLockReleasedWhenCloseFails`** injects an `IOException` during `close()` and asserts the directory can be reopened. It reproduces the leak **deterministically** — it fails without the `close()` fix (with the exact `Another process already holds a lock` error) and passes with it.

## Verification

- The new regression test fails on the old code, passes on the new code.
- Full suite on **Temurin Java 22** (CI's exact distribution): **288 passed, 0 failed, 1 skipped.**